### PR TITLE
[LED-76] Switch to h2 and enable encryption

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,9 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version: '4.11'
     testCompile group: 'org.xerial', name: 'sqlite-jdbc', version: '3.8.11.2'
     testCompile group: 'net.sf.opencsv', name: 'opencsv', version: '2.3'
+    compile group: 'com.h2database', name: 'h2', version: '1.4.192'
 
     compile group: 'org.xerial', name: 'sqlite-jdbc', version: '3.8.11.2'
     compile group: 'net.sf.opencsv', name: 'opencsv', version: '2.3'
+    compile group: 'com.h2database', name: 'h2', version: '1.4.192'
 }

--- a/src/main/java/ledger/database/storage/SQL/H2/H2Database.java
+++ b/src/main/java/ledger/database/storage/SQL/H2/H2Database.java
@@ -1,0 +1,95 @@
+package ledger.database.storage.SQL.H2;
+
+import ledger.database.storage.SQL.*;
+import ledger.database.storage.table.*;
+import ledger.exception.StorageException;
+
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.LinkedList;
+
+/**
+ * Database handler for h2 storage mechanism.
+ */
+@SuppressWarnings("SqlDialectInspection") // TODO: Find how to get this integration working.
+public class H2Database implements ISQLDatabaseTransaction, ISQLDatabaseNote, ISQLDatabasePayee, ISQLDatabaseAccount, ISQLDatabaseTag, ISQLDatabaseType {
+
+    private Connection databaseObject;
+
+    public H2Database(String pathToDb) throws StorageException {
+        // Initialize SQLite streams.
+
+        try {
+            Class.forName("org.h2.Driver");
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException("Unable to find SQLite Driver", e);
+        }
+
+        try {
+            databaseObject = DriverManager.getConnection("jdbc:h2:" + pathToDb);
+        } catch (SQLException e) {
+            throw new StorageException("Unable to connect to JDBC Socket. ");
+        }
+        initializeDatabase();
+    }
+
+    // DB management functions
+    @Override
+    public void initializeDatabase() throws StorageException {
+        LinkedList<String> tableSQL = new LinkedList<>();
+
+        tableSQL.add(TagTable.CreateStatement());
+        tableSQL.add(TypeTable.CreateStatement());
+        tableSQL.add(AccountTable.CreateStatement());
+        tableSQL.add(AccountBalanceTable.CreateStatement());
+        tableSQL.add(PayeeTable.CreateStatement());
+
+        tableSQL.add(TransactionTable.CreateStatement());
+        tableSQL.add(NoteTable.CreateStatement());
+
+        tableSQL.add(TagToTransTable.CreateStatement());
+        tableSQL.add(TagToPayeeTable.CreateStatement());
+
+        try {
+            for (String statement : tableSQL) {
+                Statement stmt = getDatabase().createStatement();
+                stmt.execute(statement);
+            }
+        } catch (SQLException e) {
+            throw new StorageException("Unable to Create Table", e);
+        }
+    }
+
+    @Override
+    public void shutdown() throws StorageException {
+        try {
+            getDatabase().close();
+        } catch (SQLException e) {
+            throw new StorageException("Exception while shutting down database.", e);
+        }
+    }
+
+    @Override
+    public void rollbackDatabase() throws StorageException {
+        try {
+            getDatabase().rollback();
+        } catch (SQLException e) {
+            throw new StorageException("Error while performing database rollback", e);
+        }
+    }
+
+    @Override
+    public void setDatabaseAutoCommit(boolean autoCommit) throws StorageException {
+        try {
+            getDatabase().setAutoCommit(autoCommit);
+        } catch (SQLException e) {
+            throw new StorageException("Error while setting database autocommit to " + autoCommit, e);
+        }
+    }
+
+    public Connection getDatabase() {
+        return databaseObject;
+    }
+}

--- a/src/main/java/ledger/database/storage/SQL/H2/H2Database.java
+++ b/src/main/java/ledger/database/storage/SQL/H2/H2Database.java
@@ -18,7 +18,7 @@ public class H2Database implements ISQLDatabaseTransaction, ISQLDatabaseNote, IS
 
     private Connection databaseObject;
 
-    public H2Database(String pathToDb) throws StorageException {
+    public H2Database(String pathToDb, String password) throws StorageException {
         // Initialize H2 streams.
 
         try {
@@ -28,7 +28,10 @@ public class H2Database implements ISQLDatabaseTransaction, ISQLDatabaseNote, IS
         }
 
         try {
-            databaseObject = DriverManager.getConnection("jdbc:h2:" + pathToDb);
+            String url = "jdbc:h2:" + pathToDb + ";CIPHER=AES";
+            String user = "TransACT";
+            String pwds = "Ledger " + password;
+            databaseObject = DriverManager.getConnection(url, user, pwds);
         } catch (SQLException e) {
             throw new StorageException("Unable to connect to JDBC Socket. ");
         }

--- a/src/main/java/ledger/database/storage/SQL/H2/H2Database.java
+++ b/src/main/java/ledger/database/storage/SQL/H2/H2Database.java
@@ -19,12 +19,12 @@ public class H2Database implements ISQLDatabaseTransaction, ISQLDatabaseNote, IS
     private Connection databaseObject;
 
     public H2Database(String pathToDb) throws StorageException {
-        // Initialize SQLite streams.
+        // Initialize H2 streams.
 
         try {
             Class.forName("org.h2.Driver");
         } catch (ClassNotFoundException e) {
-            throw new RuntimeException("Unable to find SQLite Driver", e);
+            throw new RuntimeException("Unable to find h2 Driver", e);
         }
 
         try {
@@ -40,17 +40,17 @@ public class H2Database implements ISQLDatabaseTransaction, ISQLDatabaseNote, IS
     public void initializeDatabase() throws StorageException {
         LinkedList<String> tableSQL = new LinkedList<>();
 
-        tableSQL.add(TagTable.CreateStatement());
-        tableSQL.add(TypeTable.CreateStatement());
-        tableSQL.add(AccountTable.CreateStatement());
-        tableSQL.add(AccountBalanceTable.CreateStatement());
-        tableSQL.add(PayeeTable.CreateStatement());
+        tableSQL.add(TagTable.CreateStatementH2());
+        tableSQL.add(TypeTable.CreateStatementH2());
+        tableSQL.add(AccountTable.CreateStatementH2());
+        tableSQL.add(AccountBalanceTable.CreateStatementH2());
+        tableSQL.add(PayeeTable.CreateStatementH2());
 
-        tableSQL.add(TransactionTable.CreateStatement());
-        tableSQL.add(NoteTable.CreateStatement());
+        tableSQL.add(TransactionTable.CreateStatementH2());
+        tableSQL.add(NoteTable.CreateStatementH2());
 
-        tableSQL.add(TagToTransTable.CreateStatement());
-        tableSQL.add(TagToPayeeTable.CreateStatement());
+        tableSQL.add(TagToTransTable.CreateStatementH2());
+        tableSQL.add(TagToPayeeTable.CreateStatementH2());
 
         try {
             for (String statement : tableSQL) {

--- a/src/main/java/ledger/database/storage/SQL/H2/IH2Database.java
+++ b/src/main/java/ledger/database/storage/SQL/H2/IH2Database.java
@@ -1,11 +1,11 @@
-package ledger.database.storage;
+package ledger.database.storage.SQL.H2;
 
 import ledger.database.IDatabase;
 import ledger.exception.StorageException;
 
 import java.sql.Connection;
 
-public interface ISQLiteDatabase extends IDatabase {
+public interface IH2Database extends IDatabase {
     Connection getDatabase();
 
     void rollbackDatabase() throws StorageException;

--- a/src/main/java/ledger/database/storage/SQL/ISQLDatabaseAccount.java
+++ b/src/main/java/ledger/database/storage/SQL/ISQLDatabaseAccount.java
@@ -1,6 +1,7 @@
-package ledger.database.storage;
+package ledger.database.storage.SQL;
 
 import ledger.database.enity.Account;
+import ledger.database.storage.SQL.SQLite.ISQLiteDatabase;
 import ledger.database.storage.table.AccountTable;
 import ledger.exception.StorageException;
 
@@ -10,7 +11,7 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 
-public interface ISQLiteDatabaseAccount extends ISQLiteDatabase {
+public interface ISQLDatabaseAccount extends ISQLiteDatabase {
 
     @Override
     default void insertAccount(Account account) throws StorageException {

--- a/src/main/java/ledger/database/storage/SQL/ISQLDatabaseNote.java
+++ b/src/main/java/ledger/database/storage/SQL/ISQLDatabaseNote.java
@@ -1,6 +1,7 @@
-package ledger.database.storage;
+package ledger.database.storage.SQL;
 
 import ledger.database.enity.Note;
+import ledger.database.storage.SQL.SQLite.ISQLiteDatabase;
 import ledger.database.storage.table.NoteTable;
 import ledger.exception.StorageException;
 
@@ -10,7 +11,7 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 
-public interface ISQLiteDatabaseNote extends ISQLiteDatabase {
+public interface ISQLDatabaseNote extends ISQLiteDatabase {
 
     @Override
     default void insertNote(Note note) {

--- a/src/main/java/ledger/database/storage/SQL/ISQLDatabasePayee.java
+++ b/src/main/java/ledger/database/storage/SQL/ISQLDatabasePayee.java
@@ -1,6 +1,7 @@
-package ledger.database.storage;
+package ledger.database.storage.SQL;
 
 import ledger.database.enity.Payee;
+import ledger.database.storage.SQL.SQLite.ISQLiteDatabase;
 import ledger.database.storage.table.PayeeTable;
 import ledger.exception.StorageException;
 
@@ -10,7 +11,7 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 
-public interface ISQLiteDatabasePayee extends ISQLiteDatabase {
+public interface ISQLDatabasePayee extends ISQLiteDatabase {
 
     @Override
     default void insertPayee(Payee payee) throws StorageException {

--- a/src/main/java/ledger/database/storage/SQL/ISQLDatabaseTag.java
+++ b/src/main/java/ledger/database/storage/SQL/ISQLDatabaseTag.java
@@ -1,6 +1,7 @@
-package ledger.database.storage;
+package ledger.database.storage.SQL;
 
 import ledger.database.enity.Tag;
+import ledger.database.storage.SQL.SQLite.ISQLiteDatabase;
 import ledger.database.storage.table.TagTable;
 import ledger.exception.StorageException;
 
@@ -10,7 +11,7 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 
-public interface ISQLiteDatabaseTag extends ISQLiteDatabase {
+public interface ISQLDatabaseTag extends ISQLiteDatabase {
 
     @Override
     default void insertTag(Tag tag) throws StorageException {

--- a/src/main/java/ledger/database/storage/SQL/ISQLDatabaseTransaction.java
+++ b/src/main/java/ledger/database/storage/SQL/ISQLDatabaseTransaction.java
@@ -220,7 +220,7 @@ public interface ISQLDatabaseTransaction extends ISQLiteDatabase {
                     ", " + TypeTable.TYPE_NAME +
                     ", " + TypeTable.TYPE_DESC +
                     " FROM " + TypeTable.TABLE_NAME +
-                            " WHERE " + TypeTable.TYPE_NAME + "=?");
+                    " WHERE " + TypeTable.TYPE_NAME + "=?");
 
             stmt.setString(1, name);
 
@@ -259,7 +259,7 @@ public interface ISQLDatabaseTransaction extends ISQLiteDatabase {
             PreparedStatement stmt = getDatabase().prepareStatement("SELECT " + AccountTable.ACCOUNT_ID +
                     ", " + AccountTable.ACCOUNT_NAME +
                     ", " + AccountTable.ACCOUNT_DESC +
-                    " FROM " +  AccountTable.TABLE_NAME +
+                    " FROM " + AccountTable.TABLE_NAME +
                     " WHERE " + AccountTable.ACCOUNT_NAME + "=? AND " + AccountTable.ACCOUNT_DESC + "=?");
 
             stmt.setString(1, name);
@@ -276,7 +276,7 @@ public interface ISQLDatabaseTransaction extends ISQLiteDatabase {
     default Tag getTagForNameAndDescription(String tagName, String tagDescription) {
         try {
 
-            PreparedStatement stmt = getDatabase().prepareStatement("SELECT " + TagTable.TAG_ID  +
+            PreparedStatement stmt = getDatabase().prepareStatement("SELECT " + TagTable.TAG_ID +
                     " FROM " + TagTable.TABLE_NAME +
                     " WHERE " + TagTable.TAG_NAME + "=? AND " + TagTable.TAG_DESC + "=?");
             stmt.setString(1, tagName);
@@ -479,7 +479,7 @@ public interface ISQLDatabaseTransaction extends ISQLiteDatabase {
         }
     }
 
-    default void lookupAndSetTypeForSQLStatement(Transaction transaction, PreparedStatement stmt, int statementInputIndex) throws StorageException{
+    default void lookupAndSetTypeForSQLStatement(Transaction transaction, PreparedStatement stmt, int statementInputIndex) throws StorageException {
         try {
             Type existingType;
             if (transaction.getType().getId() != -1) {

--- a/src/main/java/ledger/database/storage/SQL/ISQLDatabaseTransaction.java
+++ b/src/main/java/ledger/database/storage/SQL/ISQLDatabaseTransaction.java
@@ -1,6 +1,7 @@
-package ledger.database.storage;
+package ledger.database.storage.SQL;
 
 import ledger.database.enity.*;
+import ledger.database.storage.SQL.SQLite.ISQLiteDatabase;
 import ledger.database.storage.table.*;
 import ledger.exception.StorageException;
 
@@ -12,7 +13,7 @@ import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
 
-public interface ISQLiteDatabaseTransaction extends ISQLiteDatabase {
+public interface ISQLDatabaseTransaction extends ISQLiteDatabase {
 
     // Basic CRUD functionality
     @Override

--- a/src/main/java/ledger/database/storage/SQL/ISQLDatabaseTransaction.java
+++ b/src/main/java/ledger/database/storage/SQL/ISQLDatabaseTransaction.java
@@ -80,6 +80,18 @@ public interface ISQLDatabaseTransaction extends ISQLiteDatabase {
         try {
             setDatabaseAutoCommit(false);
 
+            //First delete the corresponding Note
+            PreparedStatement noteStatement = getDatabase().prepareStatement("DELETE FROM " + NoteTable.TABLE_NAME + " WHERE "
+                    + NoteTable.NOTE_TRANS_ID + " = ?");
+            noteStatement.setInt(1, transaction.getId());
+            noteStatement.executeUpdate();
+
+            //Delete Any Entries in TAG_TO_TRANS
+            PreparedStatement tttsStatement = getDatabase().prepareStatement("DELETE FROM " + TagToTransTable.TABLE_NAME + " WHERE "
+                    + TagToTransTable.TTTS_TRANS_ID + " = ?");
+            tttsStatement.setInt(1, transaction.getId());
+            tttsStatement.executeUpdate();
+
             PreparedStatement deleteTransactionStmt = getDatabase().prepareStatement("DELETE FROM " + TransactionTable.TABLE_NAME +
                     " WHERE " + TransactionTable.TRANS_ID + " = ?");
             deleteTransactionStmt.setInt(1, transaction.getId());

--- a/src/main/java/ledger/database/storage/SQL/ISQLDatabaseType.java
+++ b/src/main/java/ledger/database/storage/SQL/ISQLDatabaseType.java
@@ -39,7 +39,8 @@ public interface ISQLDatabaseType extends ISQLiteDatabase {
             List<Transaction> trans = getAllTransactions();
             List<Type> types = trans.stream().map(Transaction::getType).collect(Collectors.toList());
             List<Integer> ids = types.stream().map(Type::getId).collect(Collectors.toList());
-            if (ids.contains(type.getId())) throw new StorageException("Cannot delete a Type while used by Transaction");
+            if (ids.contains(type.getId()))
+                throw new StorageException("Cannot delete a Type while used by Transaction");
 
             PreparedStatement stmt = getDatabase().prepareStatement("DELETE FROM TYPE WHERE TYPE_ID = ?");
             stmt.setInt(1, type.getId());

--- a/src/main/java/ledger/database/storage/SQL/ISQLDatabaseType.java
+++ b/src/main/java/ledger/database/storage/SQL/ISQLDatabaseType.java
@@ -1,5 +1,6 @@
 package ledger.database.storage.SQL;
 
+import ledger.database.enity.Transaction;
 import ledger.database.enity.Type;
 import ledger.database.storage.SQL.SQLite.ISQLiteDatabase;
 import ledger.database.storage.table.TypeTable;
@@ -10,6 +11,7 @@ import java.sql.ResultSet;
 import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public interface ISQLDatabaseType extends ISQLiteDatabase {
     @Override
@@ -34,6 +36,11 @@ public interface ISQLDatabaseType extends ISQLiteDatabase {
     @Override
     default void deleteType(Type type) throws StorageException {
         try {
+            List<Transaction> trans = getAllTransactions();
+            List<Type> types = trans.stream().map(Transaction::getType).collect(Collectors.toList());
+            List<Integer> ids = types.stream().map(Type::getId).collect(Collectors.toList());
+            if (ids.contains(type.getId())) throw new StorageException("Cannot delete a Type while used by Transaction");
+
             PreparedStatement stmt = getDatabase().prepareStatement("DELETE FROM TYPE WHERE TYPE_ID = ?");
             stmt.setInt(1, type.getId());
             stmt.executeUpdate();

--- a/src/main/java/ledger/database/storage/SQL/ISQLDatabaseType.java
+++ b/src/main/java/ledger/database/storage/SQL/ISQLDatabaseType.java
@@ -1,6 +1,7 @@
-package ledger.database.storage;
+package ledger.database.storage.SQL;
 
 import ledger.database.enity.Type;
+import ledger.database.storage.SQL.SQLite.ISQLiteDatabase;
 import ledger.database.storage.table.TypeTable;
 import ledger.exception.StorageException;
 
@@ -10,7 +11,7 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 
-public interface ISQLiteDatabaseType extends ISQLiteDatabase {
+public interface ISQLDatabaseType extends ISQLiteDatabase {
     @Override
     default void insertType(Type type) throws StorageException {
         try {

--- a/src/main/java/ledger/database/storage/SQL/SQLite/ISQLiteDatabase.java
+++ b/src/main/java/ledger/database/storage/SQL/SQLite/ISQLiteDatabase.java
@@ -1,0 +1,14 @@
+package ledger.database.storage.SQL.SQLite;
+
+import ledger.database.IDatabase;
+import ledger.exception.StorageException;
+
+import java.sql.Connection;
+
+public interface ISQLiteDatabase extends IDatabase {
+    Connection getDatabase();
+
+    void rollbackDatabase() throws StorageException;
+
+    void setDatabaseAutoCommit(boolean autoCommit) throws StorageException;
+}

--- a/src/main/java/ledger/database/storage/SQL/SQLite/SQLiteDatabase.java
+++ b/src/main/java/ledger/database/storage/SQL/SQLite/SQLiteDatabase.java
@@ -1,21 +1,17 @@
-package ledger.database.storage;
+package ledger.database.storage.SQL.SQLite;
 
-import ledger.database.IDatabase;
-import ledger.database.enity.*;
+import ledger.database.storage.SQL.*;
 import ledger.database.storage.table.*;
 import ledger.exception.StorageException;
 
 import java.sql.*;
-import java.util.ArrayList;
-import java.util.Date;
 import java.util.LinkedList;
-import java.util.List;
 
 /**
  * Database handler for SQLite storage mechanism.
  */
 @SuppressWarnings("SqlDialectInspection") // TODO: Find how to get this integration working.
-public class SQLiteDatabase implements ISQLiteDatabaseTransaction, ISQLiteDatabaseNote, ISQLiteDatabasePayee, ISQLiteDatabaseAccount, ISQLiteDatabaseTag, ISQLiteDatabaseType {
+public class SQLiteDatabase implements ISQLDatabaseTransaction, ISQLDatabaseNote, ISQLDatabasePayee, ISQLDatabaseAccount, ISQLDatabaseTag, ISQLDatabaseType {
 
     private Connection databaseObject;
 

--- a/src/main/java/ledger/database/storage/SQL/SQLite/SQLiteDatabase.java
+++ b/src/main/java/ledger/database/storage/SQL/SQLite/SQLiteDatabase.java
@@ -37,17 +37,17 @@ public class SQLiteDatabase implements ISQLDatabaseTransaction, ISQLDatabaseNote
     public void initializeDatabase() throws StorageException {
         LinkedList<String> tableSQL = new LinkedList<>();
 
-        tableSQL.add(TagTable.CreateStatement());
-        tableSQL.add(TypeTable.CreateStatement());
-        tableSQL.add(AccountTable.CreateStatement());
-        tableSQL.add(AccountBalanceTable.CreateStatement());
-        tableSQL.add(PayeeTable.CreateStatement());
+        tableSQL.add(TagTable.CreateStatementSQLite());
+        tableSQL.add(TypeTable.CreateStatementSQLite());
+        tableSQL.add(AccountTable.CreateStatementSQLite());
+        tableSQL.add(AccountBalanceTable.CreateStatementSQLite());
+        tableSQL.add(PayeeTable.CreateStatementSQLite());
 
-        tableSQL.add(TransactionTable.CreateStatement());
-        tableSQL.add(NoteTable.CreateStatement());
+        tableSQL.add(TransactionTable.CreateStatementSQLite());
+        tableSQL.add(NoteTable.CreateStatementSQLite());
 
-        tableSQL.add(TagToTransTable.CreateStatement());
-        tableSQL.add(TagToPayeeTable.CreateStatement());
+        tableSQL.add(TagToTransTable.CreateStatementSQLite());
+        tableSQL.add(TagToPayeeTable.CreateStatementSQLite());
 
         try {
             for (String statement : tableSQL) {

--- a/src/main/java/ledger/database/storage/SQL/SQLite/SQLiteDatabase.java
+++ b/src/main/java/ledger/database/storage/SQL/SQLite/SQLiteDatabase.java
@@ -4,7 +4,10 @@ import ledger.database.storage.SQL.*;
 import ledger.database.storage.table.*;
 import ledger.exception.StorageException;
 
-import java.sql.*;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.SQLException;
+import java.sql.Statement;
 import java.util.LinkedList;
 
 /**

--- a/src/main/java/ledger/database/storage/table/AccountBalanceTable.java
+++ b/src/main/java/ledger/database/storage/table/AccountBalanceTable.java
@@ -9,6 +9,7 @@ public class AccountBalanceTable {
 
     /**
      * Creates the String command to create the table for this object.
+     *
      * @return String for creating the SQLite Table corresponding to this object
      */
     public static String CreateStatementSQLite() {
@@ -21,6 +22,7 @@ public class AccountBalanceTable {
 
     /**
      * Creates the String command to create the table for this object.
+     *
      * @return String for creating the H2 Table corresponding to this object
      */
     public static String CreateStatementH2() {

--- a/src/main/java/ledger/database/storage/table/AccountBalanceTable.java
+++ b/src/main/java/ledger/database/storage/table/AccountBalanceTable.java
@@ -2,12 +2,6 @@ package ledger.database.storage.table;
 
 public class AccountBalanceTable {
 
-    private static final String tableAccountBalance = "CREATE TABLE IF NOT EXISTS ACCOUNT_BALANCE " +
-            "(ABAL_ACCOUNT_ID INTEGER PRIMARY KEY AUTOINCREMENT, " +
-            "ABAL_DATETIME REAL         NOT NULL, " +
-            "ABAL_AMOUNT INT            NOT NULL " +
-            ")";
-
     public static String TABLE_NAME = "ACCOUNT_BALANCE";
     public static String ABAL_ACCOUNT_ID = "ABAL_ACCOUNT_ID";
     public static String ABAL_DATETIME = "ABAL_DATETIME";
@@ -17,9 +11,21 @@ public class AccountBalanceTable {
      * Creates the String command to create the table for this object.
      * @return String for creating the SQLite Table corresponding to this object
      */
-    public static String CreateStatement() {
+    public static String CreateStatementSQLite() {
         return String.format("CREATE TABLE IF NOT EXISTS %s " +
                 "(%s INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                "%s REAL NOT NULL, " +
+                "%s INT NOT NULL" +
+                ")", TABLE_NAME, ABAL_ACCOUNT_ID, ABAL_DATETIME, ABAL_AMOUNT);
+    }
+
+    /**
+     * Creates the String command to create the table for this object.
+     * @return String for creating the H2 Table corresponding to this object
+     */
+    public static String CreateStatementH2() {
+        return String.format("CREATE TABLE IF NOT EXISTS %s " +
+                "(%s INTEGER PRIMARY KEY AUTO_INCREMENT, " +
                 "%s REAL NOT NULL, " +
                 "%s INT NOT NULL" +
                 ")", TABLE_NAME, ABAL_ACCOUNT_ID, ABAL_DATETIME, ABAL_AMOUNT);

--- a/src/main/java/ledger/database/storage/table/AccountTable.java
+++ b/src/main/java/ledger/database/storage/table/AccountTable.java
@@ -1,11 +1,6 @@
 package ledger.database.storage.table;
 
 public class AccountTable {
-    private static final String tableAccount = "CREATE TABLE IF NOT EXISTS ACCOUNT " +
-            "(ACCOUNT_ID INTEGER PRIMARY KEY AUTOINCREMENT, " +
-            "ACCOUNT_NAME TEXT           NOT NULL, " +
-            "ACCOUNT_DESC TEXT           NOT NULL" +
-            ")";
 
     public static final String TABLE_NAME = "ACCOUNT";
 
@@ -17,9 +12,21 @@ public class AccountTable {
      * Creates the String command to create the table for this object.
      * @return String for creating the SQLite Table corresponding to this object
      */
-    public static String CreateStatement() {
+    public static String CreateStatementSQLite() {
         return String.format("CREATE TABLE IF NOT EXISTS %s " +
                 "(%s INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                "%s TEXT NOT NULL, " +
+                "%s TEXT NOT NULL" +
+                ")", TABLE_NAME, ACCOUNT_ID, ACCOUNT_NAME, ACCOUNT_DESC);
+    }
+
+    /**
+     * Creates the String command to create the table for this object.
+     * @return String for creating the H2 Table corresponding to this object
+     */
+    public static String CreateStatementH2() {
+        return String.format("CREATE TABLE IF NOT EXISTS %s " +
+                "(%s INTEGER PRIMARY KEY AUTO_INCREMENT, " +
                 "%s TEXT NOT NULL, " +
                 "%s TEXT NOT NULL" +
                 ")", TABLE_NAME, ACCOUNT_ID, ACCOUNT_NAME, ACCOUNT_DESC);

--- a/src/main/java/ledger/database/storage/table/AccountTable.java
+++ b/src/main/java/ledger/database/storage/table/AccountTable.java
@@ -10,6 +10,7 @@ public class AccountTable {
 
     /**
      * Creates the String command to create the table for this object.
+     *
      * @return String for creating the SQLite Table corresponding to this object
      */
     public static String CreateStatementSQLite() {
@@ -22,6 +23,7 @@ public class AccountTable {
 
     /**
      * Creates the String command to create the table for this object.
+     *
      * @return String for creating the H2 Table corresponding to this object
      */
     public static String CreateStatementH2() {

--- a/src/main/java/ledger/database/storage/table/NoteTable.java
+++ b/src/main/java/ledger/database/storage/table/NoteTable.java
@@ -8,6 +8,7 @@ public class NoteTable {
 
     /**
      * Creates the String command to create the table for this object.
+     *
      * @return String for creating the SQLite Table corresponding to this object
      */
     public static String CreateStatementSQLite() {
@@ -20,6 +21,7 @@ public class NoteTable {
 
     /**
      * Creates the String command to create the table for this object.
+     *
      * @return String for creating the H2 Table corresponding to this object
      */
     public static String CreateStatementH2() {

--- a/src/main/java/ledger/database/storage/table/NoteTable.java
+++ b/src/main/java/ledger/database/storage/table/NoteTable.java
@@ -2,12 +2,6 @@ package ledger.database.storage.table;
 
 public class NoteTable {
 
-    private static final String tableNote = "CREATE TABLE IF NOT EXISTS NOTE" +
-            "(NOTE_TRANS_ID INTEGER PRIMARY KEY AUTOINCREMENT, " +
-            "NOTE_TEXT TEXT             NOT NULL, " +
-            "FOREIGN KEY(NOTE_TRANS_ID) REFERENCES TRANSACT(TRANS_ID)" +
-            ")";
-
     public static final String TABLE_NAME = "NOTE";
     public static final String NOTE_TRANS_ID = "NOTE_TRANS_ID";
     public static final String NOTE_TEXT = "NOTE_TEXT";
@@ -16,9 +10,21 @@ public class NoteTable {
      * Creates the String command to create the table for this object.
      * @return String for creating the SQLite Table corresponding to this object
      */
-    public static String CreateStatement() {
+    public static String CreateStatementSQLite() {
         return String.format("CREATE TABLE IF NOT EXISTS %s " +
                 "(%s INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                "%s TEXT NOT NULL, " +
+                "FOREIGN KEY(%s) REFERENCES %s(%s)" +
+                ")", TABLE_NAME, NOTE_TRANS_ID, NOTE_TEXT, NOTE_TRANS_ID, TransactionTable.TABLE_NAME, TransactionTable.TRANS_ID);
+    }
+
+    /**
+     * Creates the String command to create the table for this object.
+     * @return String for creating the H2 Table corresponding to this object
+     */
+    public static String CreateStatementH2() {
+        return String.format("CREATE TABLE IF NOT EXISTS %s " +
+                "(%s INTEGER PRIMARY KEY AUTO_INCREMENT, " +
                 "%s TEXT NOT NULL, " +
                 "FOREIGN KEY(%s) REFERENCES %s(%s)" +
                 ")", TABLE_NAME, NOTE_TRANS_ID, NOTE_TEXT, NOTE_TRANS_ID, TransactionTable.TABLE_NAME, TransactionTable.TRANS_ID);

--- a/src/main/java/ledger/database/storage/table/PayeeTable.java
+++ b/src/main/java/ledger/database/storage/table/PayeeTable.java
@@ -2,12 +2,6 @@ package ledger.database.storage.table;
 
 public class PayeeTable {
 
-    private static final String tablePayee = "CREATE TABLE IF NOT EXISTS PAYEE " +
-            "(PAYEE_ID INTEGER PRIMARY KEY AUTOINCREMENT, " +
-            "PAYEE_NAME TEXT           NOT NULL, " +
-            "PAYEE_DESC TEXT           NOT NULL" +
-            ")";
-
     public static String TABLE_NAME = "PAYEE";
     public static String PAYEE_ID = "PAYEE_ID";
     public static String PAYEE_NAME = "PAYEE_NAME";
@@ -17,9 +11,21 @@ public class PayeeTable {
      * Creates the String command to create the table for this object.
      * @return String for creating the SQLite Table corresponding to this object
      */
-    public static String CreateStatement() {
+    public static String CreateStatementSQLite() {
         return String.format("CREATE TABLE IF NOT EXISTS %s " +
                 "(%s INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                "%s TEXT NOT NULL, " +
+                "%s TEXT NOT NULL" +
+                ")", TABLE_NAME, PAYEE_ID, PAYEE_NAME, PAYEE_DESC);
+    }
+
+    /**
+     * Creates the String command to create the table for this object.
+     * @return String for creating the H2 Table corresponding to this object
+     */
+    public static String CreateStatementH2() {
+        return String.format("CREATE TABLE IF NOT EXISTS %s " +
+                "(%s INTEGER PRIMARY KEY AUTO_INCREMENT, " +
                 "%s TEXT NOT NULL, " +
                 "%s TEXT NOT NULL" +
                 ")", TABLE_NAME, PAYEE_ID, PAYEE_NAME, PAYEE_DESC);

--- a/src/main/java/ledger/database/storage/table/PayeeTable.java
+++ b/src/main/java/ledger/database/storage/table/PayeeTable.java
@@ -9,6 +9,7 @@ public class PayeeTable {
 
     /**
      * Creates the String command to create the table for this object.
+     *
      * @return String for creating the SQLite Table corresponding to this object
      */
     public static String CreateStatementSQLite() {
@@ -21,6 +22,7 @@ public class PayeeTable {
 
     /**
      * Creates the String command to create the table for this object.
+     *
      * @return String for creating the H2 Table corresponding to this object
      */
     public static String CreateStatementH2() {

--- a/src/main/java/ledger/database/storage/table/TagTable.java
+++ b/src/main/java/ledger/database/storage/table/TagTable.java
@@ -2,12 +2,6 @@ package ledger.database.storage.table;
 
 public class TagTable {
 
-    static final String tableTag = "CREATE TABLE IF NOT EXISTS TAG " +
-            "(TAG_ID INTEGER PRIMARY KEY    AUTOINCREMENT, " +
-            "TAG_NAME TEXT              NOT NULL, " +
-            "TAG_DESC TEXT              NOT NULL" +
-            ")";
-
     public static String TABLE_NAME = "TAG";
     public static String TAG_ID = "TAG_ID";
     public static String TAG_NAME = "TAG_NAME";
@@ -17,9 +11,21 @@ public class TagTable {
      * Creates the String command to create the table for this object.
      * @return String for creating the SQLite Table corresponding to this object
      */
-    public static String CreateStatement() {
+    public static String CreateStatementSQLite() {
         return String.format("CREATE TABLE IF NOT EXISTS %s " +
                 "(%s INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                "%s TEXT NOT NULL, " +
+                "%s TEXT NOT NULL" +
+                ")", TABLE_NAME, TAG_ID, TAG_NAME, TAG_DESC);
+    }
+
+    /**
+     * Creates the String command to create the table for this object.
+     * @return String for creating the H2 Table corresponding to this object
+     */
+    public static String CreateStatementH2() {
+        return String.format("CREATE TABLE IF NOT EXISTS %s " +
+                "(%s INTEGER PRIMARY KEY AUTO_INCREMENT, " +
                 "%s TEXT NOT NULL, " +
                 "%s TEXT NOT NULL" +
                 ")", TABLE_NAME, TAG_ID, TAG_NAME, TAG_DESC);

--- a/src/main/java/ledger/database/storage/table/TagTable.java
+++ b/src/main/java/ledger/database/storage/table/TagTable.java
@@ -9,6 +9,7 @@ public class TagTable {
 
     /**
      * Creates the String command to create the table for this object.
+     *
      * @return String for creating the SQLite Table corresponding to this object
      */
     public static String CreateStatementSQLite() {
@@ -21,6 +22,7 @@ public class TagTable {
 
     /**
      * Creates the String command to create the table for this object.
+     *
      * @return String for creating the H2 Table corresponding to this object
      */
     public static String CreateStatementH2() {

--- a/src/main/java/ledger/database/storage/table/TagToPayeeTable.java
+++ b/src/main/java/ledger/database/storage/table/TagToPayeeTable.java
@@ -2,13 +2,6 @@ package ledger.database.storage.table;
 
 public class TagToPayeeTable {
 
-    private static final String tableTagToPayee = "CREATE TABLE IF NOT EXISTS TAG_TO_PAYEE " +
-            "(TTPE_TAG_ID INT           NOT NULL, " +
-            "TTPE_PAYEE_ID INT          NOT NULL, " +
-            "FOREIGN KEY(TTPE_TAG_ID) REFERENCES TAG(TAG_ID), " +
-            "FOREIGN KEY(TTPE_PAYEE_ID) REFERENCES PAYEE(PAYEE_ID)" +
-            ")";
-
     public static String TABLE_NAME = "TAG_TO_PAYEE";
     public static String TTPE_TAG_ID = "TTPE_TAG_ID";
     public static String TTPE_PAYEE_ID = "TTPE_PAYEE_ID";
@@ -17,7 +10,7 @@ public class TagToPayeeTable {
      * Creates the String command to create the table for this object.
      * @return String for creating the SQLite Table corresponding to this object
      */
-    public static String CreateStatement() {
+    public static String CreateStatementSQLite() {
         return String.format("CREATE TABLE IF NOT EXISTS %s " +
                         "(%s INT NOT NULL, " +
                         "%s INT NOT NULL, " +
@@ -27,5 +20,13 @@ public class TagToPayeeTable {
                 TTPE_TAG_ID, TagTable.TABLE_NAME, TagTable.TAG_ID,
                 TTPE_PAYEE_ID, PayeeTable.TABLE_NAME, PayeeTable.PAYEE_ID
         );
+    }
+
+    /**
+     * Creates the String command to create the table for this object.
+     * @return String for creating the H2 Table corresponding to this object
+     */
+    public static String CreateStatementH2() {
+        return CreateStatementSQLite(); //The same in this case
     }
 }

--- a/src/main/java/ledger/database/storage/table/TagToPayeeTable.java
+++ b/src/main/java/ledger/database/storage/table/TagToPayeeTable.java
@@ -8,6 +8,7 @@ public class TagToPayeeTable {
 
     /**
      * Creates the String command to create the table for this object.
+     *
      * @return String for creating the SQLite Table corresponding to this object
      */
     public static String CreateStatementSQLite() {
@@ -24,6 +25,7 @@ public class TagToPayeeTable {
 
     /**
      * Creates the String command to create the table for this object.
+     *
      * @return String for creating the H2 Table corresponding to this object
      */
     public static String CreateStatementH2() {

--- a/src/main/java/ledger/database/storage/table/TagToTransTable.java
+++ b/src/main/java/ledger/database/storage/table/TagToTransTable.java
@@ -2,13 +2,6 @@ package ledger.database.storage.table;
 
 public class TagToTransTable {
 
-    private static final String tableTagToTrans = "CREATE TABLE IF NOT EXISTS TAG_TO_TRANS " +
-            "(TTTS_TAG_ID INT           NOT NULL, " +
-            "TTTS_TRANS_ID INT          NOT NULL, " +
-            "FOREIGN KEY(TTTS_TAG_ID) REFERENCES TAG(TAG_ID), " +
-            "FOREIGN KEY(TTTS_TRANS_ID) REFERENCES TRANSACT(TRANS_ID)" +
-            ")";
-
     public static String TABLE_NAME = "TAG_TO_TRANS";
     public static String TTTS_TAG_ID = "TTTS_TAG_ID";
     public static String TTTS_TRANS_ID = "TTTS_TRANS_ID";
@@ -17,7 +10,7 @@ public class TagToTransTable {
      * Creates the String command to create the table for this object.
      * @return String for creating the SQLite Table corresponding to this object
      */
-    public static String CreateStatement() {
+    public static String CreateStatementSQLite() {
         return String.format("CREATE TABLE IF NOT EXISTS %s " +
                         "(%s INT NOT NULL, " +
                         "%s INT NOT NULL, " +
@@ -27,5 +20,13 @@ public class TagToTransTable {
                 TTTS_TAG_ID, TagTable.TABLE_NAME, TagTable.TAG_ID,
                 TTTS_TRANS_ID, TransactionTable.TABLE_NAME, TransactionTable.TRANS_ID
         );
+    }
+
+    /**
+     * Creates the String command to create the table for this object.
+     * @return String for creating the H2 Table corresponding to this object
+     */
+    public static String CreateStatementH2() {
+        return CreateStatementSQLite(); // the same in this case
     }
 }

--- a/src/main/java/ledger/database/storage/table/TagToTransTable.java
+++ b/src/main/java/ledger/database/storage/table/TagToTransTable.java
@@ -8,6 +8,7 @@ public class TagToTransTable {
 
     /**
      * Creates the String command to create the table for this object.
+     *
      * @return String for creating the SQLite Table corresponding to this object
      */
     public static String CreateStatementSQLite() {
@@ -24,6 +25,7 @@ public class TagToTransTable {
 
     /**
      * Creates the String command to create the table for this object.
+     *
      * @return String for creating the H2 Table corresponding to this object
      */
     public static String CreateStatementH2() {

--- a/src/main/java/ledger/database/storage/table/TransactionTable.java
+++ b/src/main/java/ledger/database/storage/table/TransactionTable.java
@@ -2,19 +2,6 @@ package ledger.database.storage.table;
 
 public class TransactionTable {
 
-    private static final String tableTransaction = "CREATE TABLE IF NOT EXISTS TRANSACT " +
-            "(TRANS_ID INTEGER PRIMARY KEY  AUTOINCREMENT, " +
-            "TRANS_DATETIME REAL        NOT NULL, " +
-            "TRANS_AMOUNT INT           NOT NULL," +
-            "TRANS_PENDING BOOLEAN      NOT NULL, " +
-            "TRANS_ACCOUNT_ID INT       NOT NULL, " +
-            "TRANS_PAYEE_ID INT         NOT NULL, " +
-            "TRANS_TYPE_ID INT          NOT NULL, " +
-            "FOREIGN KEY(TRANS_ACCOUNT_ID) REFERENCES ACCOUNT(ACCOUNT_ID), " +
-            "FOREIGN KEY(TRANS_PAYEE_ID) REFERENCES PAYEE(PAYEE_ID)," +
-            "FOREIGN KEY(TRANS_TYPE_ID) REFERENCES TYPE(TYPE_ID)" +
-            ")";
-
     public static final String TABLE_NAME = "TRANSACT";
     public static final String TRANS_ID = "TRANS_ID";
     public static final String TRANS_DATETIME = "TRANS_DATETIME";
@@ -28,7 +15,7 @@ public class TransactionTable {
      * Creates the String command to create the table for this object.
      * @return String for creating the SQLite Table corresponding to this object
      */
-    public static String CreateStatement() {
+    public static String CreateStatementSQLite() {
         return String.format("CREATE TABLE IF NOT EXISTS %s " +
                         "(%s INTEGER PRIMARY KEY AUTOINCREMENT, " +
                         "%s REAL NOT NULL, " +
@@ -48,4 +35,27 @@ public class TransactionTable {
         );
     }
 
+    /**
+     * Creates the String command to create the table for this object.
+     * @return String for creating the H2 Table corresponding to this object
+     */
+    public static String CreateStatementH2() {
+        return String.format("CREATE TABLE IF NOT EXISTS %s " +
+                        "(%s INTEGER PRIMARY KEY AUTO_INCREMENT, " +
+                        "%s REAL NOT NULL, " +
+                        "%s INT NOT NULL, " +
+                        "%s BOOLEAN NOT NULL, " +
+                        "%s INT NOT NULL, " +
+                        "%s INT NOT NULL, " +
+                        "%s INT NOT NULL, " +
+                        "FOREIGN KEY(%s) REFERENCES %s(%s), " +
+                        "FOREIGN KEY(%s) REFERENCES %s(%s)," +
+                        "FOREIGN KEY(%s) REFERENCES %s(%s)" +
+                        ")", TABLE_NAME,
+                TRANS_ID, TRANS_DATETIME, TRANS_AMOUNT, TRANS_PENDING, TRANS_ACCOUNT_ID, TRANS_PAYEE_ID, TRANS_TYPE_ID,
+                TRANS_ACCOUNT_ID, AccountTable.TABLE_NAME, AccountTable.ACCOUNT_ID,
+                TRANS_PAYEE_ID, PayeeTable.TABLE_NAME, PayeeTable.PAYEE_ID,
+                TRANS_TYPE_ID, TypeTable.TABLE_NAME, TypeTable.TYPE_ID
+        );
+    }
 }

--- a/src/main/java/ledger/database/storage/table/TransactionTable.java
+++ b/src/main/java/ledger/database/storage/table/TransactionTable.java
@@ -13,6 +13,7 @@ public class TransactionTable {
 
     /**
      * Creates the String command to create the table for this object.
+     *
      * @return String for creating the SQLite Table corresponding to this object
      */
     public static String CreateStatementSQLite() {
@@ -37,6 +38,7 @@ public class TransactionTable {
 
     /**
      * Creates the String command to create the table for this object.
+     *
      * @return String for creating the H2 Table corresponding to this object
      */
     public static String CreateStatementH2() {

--- a/src/main/java/ledger/database/storage/table/TypeTable.java
+++ b/src/main/java/ledger/database/storage/table/TypeTable.java
@@ -2,12 +2,6 @@ package ledger.database.storage.table;
 
 public class TypeTable {
 
-    private static final String tableType = "CREATE TABLE IF NOT EXISTS TYPE " +
-            "(TYPE_ID INTEGER PRIMARY KEY    AUTOINCREMENT, " +
-            "TYPE_NAME TEXT              NOT NULL, " +
-            "TYPE_DESC TEXT              NOT NULL" +
-            ")";
-
     public static String TABLE_NAME = "TYPE";
     public static String TYPE_ID = "TYPE_ID";
     public static String TYPE_NAME = "TYPE_NAME";
@@ -17,9 +11,21 @@ public class TypeTable {
      * Creates the String command to create the table for this object.
      * @return String for creating the SQLite Table corresponding to this object
      */
-    public static String CreateStatement() {
+    public static String CreateStatementSQLite() {
         return String.format("CREATE TABLE IF NOT EXISTS %s " +
                 "(%s INTEGER PRIMARY KEY AUTOINCREMENT, " +
+                "%s TEXT NOT NULL, " +
+                "%s TEXT NOT NULL" +
+                ")", TABLE_NAME, TYPE_ID, TYPE_NAME, TYPE_DESC);
+    }
+
+    /**
+     * Creates the String command to create the table for this object.
+     * @return String for creating the H2 Table corresponding to this object
+     */
+    public static String CreateStatementH2() {
+        return String.format("CREATE TABLE IF NOT EXISTS %s " +
+                "(%s INTEGER PRIMARY KEY AUTO_INCREMENT, " +
                 "%s TEXT NOT NULL, " +
                 "%s TEXT NOT NULL" +
                 ")", TABLE_NAME, TYPE_ID, TYPE_NAME, TYPE_DESC);

--- a/src/main/java/ledger/database/storage/table/TypeTable.java
+++ b/src/main/java/ledger/database/storage/table/TypeTable.java
@@ -9,6 +9,7 @@ public class TypeTable {
 
     /**
      * Creates the String command to create the table for this object.
+     *
      * @return String for creating the SQLite Table corresponding to this object
      */
     public static String CreateStatementSQLite() {
@@ -21,6 +22,7 @@ public class TypeTable {
 
     /**
      * Creates the String command to create the table for this object.
+     *
      * @return String for creating the H2 Table corresponding to this object
      */
     public static String CreateStatementH2() {

--- a/src/test/java/ledger/H2Test.java
+++ b/src/test/java/ledger/H2Test.java
@@ -1,0 +1,93 @@
+package ledger;
+
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.ResultSet;
+import java.sql.Statement;
+
+import static org.junit.Assert.assertEquals;
+
+public class H2Test {
+    static Connection dbConnection;
+
+    @BeforeClass
+    public static void SetupSQLiteConnection() throws java.sql.SQLException, ClassNotFoundException {
+        Class.forName("org.h2.Driver");
+        dbConnection = DriverManager.getConnection("jdbc:h2:./src/test/resources/testH2");
+
+        Statement stmt = dbConnection.createStatement();
+        String createTableSQL = "CREATE TABLE COMPANY " +
+                "(ID INT PRIMARY KEY     NOT NULL," +
+                " NAME           TEXT    NOT NULL, " +
+                " AGE            INT     NOT NULL, " +
+                " ADDRESS        CHAR(50), " +
+                " SALARY         REAL)";
+        stmt.executeUpdate(createTableSQL);
+        stmt.close();
+    }
+
+    @Test
+    public void TestSQLiteCRUD() throws java.sql.SQLException {
+        Statement stmt = this.dbConnection.createStatement();
+
+        String insertionSQL1 = "INSERT INTO COMPANY (ID,NAME,AGE,ADDRESS,SALARY) " +
+                "VALUES (1, 'Paul', 32, 'California', 20000.00 );";
+        stmt.executeUpdate(insertionSQL1);
+
+        String insertionSQL2 = "INSERT INTO COMPANY (ID,NAME,AGE,ADDRESS,SALARY) " +
+                "VALUES (2, 'Allen', 25, 'Texas', 15000.00 );";
+        stmt.executeUpdate(insertionSQL2);
+
+        String insertionSQL3 = "INSERT INTO COMPANY (ID,NAME,AGE,ADDRESS,SALARY) " +
+                "VALUES (3, 'Teddy', 23, 'Norway', 20000.00 );";
+        stmt.executeUpdate(insertionSQL3);
+
+        String insertionSQL4 = "INSERT INTO COMPANY (ID,NAME,AGE,ADDRESS,SALARY) " +
+                "VALUES (4, 'Mark', 25, 'Rich-Mond ', 65000.00 );";
+        stmt.executeUpdate(insertionSQL4);
+
+        int resultSetSize = 0;
+
+        ResultSet rs = stmt.executeQuery("SELECT * FROM COMPANY;");
+
+        while (rs.next()) {
+            resultSetSize++;
+        }
+        assertEquals(4, resultSetSize);
+
+        resultSetSize = 0;
+
+        String deletionSQL = "DELETE from COMPANY where ID=2";
+        stmt.executeUpdate(deletionSQL);
+
+        rs = stmt.executeQuery("SELECT * FROM COMPANY;");
+
+        while (rs.next()) {
+            resultSetSize++;
+        }
+        assertEquals(3, resultSetSize);
+
+        rs.close();
+        stmt.close();
+    }
+
+    @AfterClass
+    public static void TeardownSQLiteConnection() throws java.sql.SQLException, java.io.IOException {
+        Statement stmt = dbConnection.createStatement();
+        String dropTableSQL = "DROP TABLE COMPANY";
+        stmt.executeUpdate(dropTableSQL);
+        stmt.close();
+
+        dbConnection.close();
+
+        Path dbPath = Paths.get("src/test/resources/testH2.mv.db");
+        Files.delete(dbPath);
+    }
+}

--- a/src/test/java/ledger/database/storage/H2DatabaseTest.java
+++ b/src/test/java/ledger/database/storage/H2DatabaseTest.java
@@ -1,0 +1,503 @@
+package ledger.database.storage;
+
+import ledger.database.IDatabase;
+import ledger.database.enity.*;
+import ledger.database.storage.SQL.H2.H2Database;
+import ledger.database.storage.SQL.SQLite.SQLiteDatabase;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static org.junit.Assert.*;
+
+public class H2DatabaseTest {
+
+    private static IDatabase database;
+    private static Transaction sampleTransaction1;
+    private static Transaction sampleTransaction2;
+    private static Transaction sampleTransaction3;
+    private static Type sampleType;
+    private static Type sampleType2;
+    private static Account sampleAccount;
+    private static Payee samplePayee;
+    private static Tag sampleTag;
+    private static Tag sampleTag2;
+    private static Note sampleNote;
+    private static Note sampleNote2;
+
+    @BeforeClass
+    public static void setupDatabase() throws Exception {
+        database = new H2Database("./src/test/resources/test.db");
+    }
+
+    @Before
+    public void setupTestData() throws Exception {
+        sampleType = new Type("Credit", "Purchased with a credit card");
+        sampleType2 = new Type("Debit", "Purchased with a debit card");
+        sampleAccount = new Account("Chase", "Credit account with Chase Bank");
+        samplePayee = new Payee("Meijer", "Grocery store");
+        sampleTag = new Tag("Groceries", "Money spent on groceries");
+        sampleTag2 = new Tag("Electronics", "Money spent on electronics");
+        sampleNote = new Note("This is a note");
+        sampleNote2 = new Note("This is also a note");
+
+        ArrayList<Tag> sampleTagList = new ArrayList<>();
+        sampleTagList.add(sampleTag);
+
+        sampleTransaction1 = new Transaction(new Date(), sampleType, 4201, sampleAccount, samplePayee, true, sampleTagList, sampleNote);
+        sampleTransaction2 = new Transaction(new Date(), sampleType, 103, sampleAccount, samplePayee, true, sampleTagList, sampleNote);
+        sampleTransaction3 = new Transaction(new Date(), sampleType, 3304, sampleAccount, samplePayee, false, sampleTagList, sampleNote);
+
+        database.insertType(sampleType);
+        database.insertType(sampleType2);
+    }
+
+    @Test
+    public void insertTransaction() throws Exception {
+        int sizeBefore = database.getAllTransactions().size();
+
+        database.insertTransaction(sampleTransaction1);
+
+        List<Transaction> trans = database.getAllTransactions();
+
+        Transaction insertedTransaction = null;
+        for (Transaction t : trans) {
+            if (t.getId() == sampleTransaction1.getId()) insertedTransaction = t;
+        }
+
+        if (insertedTransaction == null) fail();
+
+        assertEquals(sizeBefore + 1, trans.size());
+        assertEquals(sampleTransaction1.getAmount(), insertedTransaction.getAmount());
+        assertEquals(sampleTransaction1.isPending(), insertedTransaction.isPending());
+        assertEquals(sampleTransaction1.getNote().getNoteText(), insertedTransaction.getNote().getNoteText());
+
+        // Check that IDs are written back to java objects
+        assertEquals(insertedTransaction.getAccount().getId(), sampleTransaction1.getAccount().getId());
+        assertEquals(insertedTransaction.getPayee().getId(), sampleTransaction1.getPayee().getId());
+        assertEquals(insertedTransaction.getType().getId(), sampleTransaction1.getType().getId());
+        for (int i = 0; i < insertedTransaction.getTagList().size(); i++) {
+            assertEquals(insertedTransaction.getTagList().get(i).getId(), sampleTransaction1.getTagList().get(i).getId());
+        }
+    }
+
+    @Test
+    public void deleteTransaction() throws Exception {
+        database.insertTransaction(sampleTransaction1);
+        database.insertTransaction(sampleTransaction2);
+        database.insertTransaction(sampleTransaction3);
+
+        List<Transaction> transactionsBeforeDelete = database.getAllTransactions();
+        int countBeforeDelete = transactionsBeforeDelete.size();
+
+        Transaction transactionToDelete = transactionsBeforeDelete.get(0); //arbitrary
+        database.deleteTransaction(transactionToDelete);
+
+        List<Transaction> transactionsAfterDelete = database.getAllTransactions();
+        int countAfterDelete = transactionsAfterDelete.size();
+
+        assertEquals(countBeforeDelete - 1, countAfterDelete);
+
+        ArrayList<Integer> IDsAfterDelete = transactionsAfterDelete.stream()
+                .map(Transaction::getId).collect(Collectors.toCollection(ArrayList::new));
+
+        assertFalse(IDsAfterDelete.contains(transactionToDelete.getId()));
+    }
+
+    @Test
+    public void editTransaction() throws Exception {
+        ArrayList<Tag> sampleTagList = new ArrayList<>();
+        sampleTagList.add(sampleTag);
+
+        Transaction originalTransaction = new Transaction(new Date(), sampleType, 1202, sampleAccount, samplePayee,
+                false, sampleTagList, sampleNote);
+
+        database.insertTransaction(originalTransaction);
+        int idBefore = originalTransaction.getId();
+
+        int amountToSet = 99999;
+        originalTransaction.setAmount(amountToSet);
+        database.editTransaction(originalTransaction);
+
+        List<Transaction> transactions = database.getAllTransactions();
+
+        Transaction editedTransaction = null;
+
+        for (Transaction t : transactions) {
+            if (t.getId() == originalTransaction.getId()) editedTransaction = t;
+        }
+
+        if (editedTransaction == null) fail();
+
+        assertEquals(amountToSet, editedTransaction.getAmount());
+        assertEquals(idBefore, editedTransaction.getId());
+    }
+
+    @Test
+    public void getAllTransactions() throws Exception {
+        int sizeBefore = database.getAllTransactions().size();
+
+        database.insertTransaction(sampleTransaction1);
+        database.insertTransaction(sampleTransaction2);
+        database.insertTransaction(sampleTransaction3);
+
+        List<Transaction> trans = database.getAllTransactions();
+
+        assertEquals(sizeBefore + 3, trans.size());
+
+        //pull out ids
+        List<Integer> ids = trans.stream().map(Transaction::getId).collect(Collectors.toList());
+
+        assertTrue(ids.contains(sampleTransaction1.getId()));
+        assertTrue(ids.contains(sampleTransaction2.getId()));
+        assertTrue(ids.contains(sampleTransaction3.getId()));
+    }
+
+    @Test
+    public void insertAccount() throws Exception {
+        int sizeBefore = database.getAllAccounts().size();
+
+        database.insertAccount(sampleAccount);
+
+        List<Account> accounts = database.getAllAccounts();
+        assertEquals(sizeBefore + 1, accounts.size());
+
+        Account insertedAccount = null;
+        for (Account a : accounts) {
+            if (a.getId() == sampleAccount.getId()) insertedAccount = a;
+        }
+
+        if (insertedAccount == null) fail(); //wasn't in db for whatever reason
+
+        assertEquals(sampleAccount.getId(), insertedAccount.getId());
+        assertEquals("Chase", insertedAccount.getName());
+        assertEquals("Credit account with Chase Bank", insertedAccount.getDescription());
+    }
+
+    @Test
+    public void deleteAccount() throws Exception {
+        database.insertAccount(sampleAccount);
+        Account randomAcc = new Account("test", "description");
+        database.insertAccount(randomAcc);
+
+        List<Account> accountsBeforeDelete = database.getAllAccounts();
+        int countBeforeDelete = accountsBeforeDelete.size();
+
+        Account accountToDelete = accountsBeforeDelete.get(0); //arbitrary
+        int deletedId = accountToDelete.getId();
+        database.deleteAccount(accountToDelete);
+
+        List<Account> accountsAfterDelete = database.getAllAccounts();
+        int countAfterDelete = accountsAfterDelete.size();
+
+        assertEquals(countBeforeDelete - 1, countAfterDelete);
+
+        ArrayList<Integer> IDsAfterDelete = new ArrayList<>();
+        for (Account currentAccount : accountsAfterDelete) {
+            IDsAfterDelete.add(currentAccount.getId());
+        }
+
+        assertFalse(IDsAfterDelete.contains(deletedId));
+    }
+
+    @Test
+    public void editAccount() throws Exception {
+        database.insertAccount(sampleAccount);
+
+        List<Account> accounts = database.getAllAccounts();
+
+        sampleAccount.setDescription("New Description");
+
+        database.editAccount(sampleAccount);
+
+        List<Account> newAccounts = database.getAllAccounts();
+
+        Account editedAccount = null;
+
+        for (Account a : newAccounts) {
+            if (a.getId() == sampleAccount.getId()) editedAccount = a;
+        }
+
+        if (editedAccount == null) fail(); // ID was no longer in DB
+
+        assertEquals(sampleAccount.getId(), editedAccount.getId());
+        assertEquals(accounts.size(), newAccounts.size());
+        assertEquals("New Description", editedAccount.getDescription());
+    }
+
+    @Test
+    public void insertPayee() throws Exception {
+        int sizeBefore = database.getAllPayees().size();
+
+        database.insertPayee(samplePayee);
+
+        List<Payee> payees = database.getAllPayees();
+        assertEquals(sizeBefore + 1, payees.size());
+
+        Payee insertedPayee = null;
+
+        for (Payee p : payees) {
+            if (p.getId() == samplePayee.getId()) insertedPayee = p;
+        }
+
+        if (insertedPayee == null) fail();
+
+        assertEquals(samplePayee.getId(), insertedPayee.getId());
+        assertEquals(samplePayee.getName(), insertedPayee.getName());
+        assertEquals(samplePayee.getDescription(), insertedPayee.getDescription());
+    }
+
+    @Test
+    public void deletePayee() throws Exception {
+        int sizeBefore = database.getAllPayees().size();
+
+        database.insertPayee(samplePayee);
+
+        List<Payee> payees = database.getAllPayees();
+        assertEquals(sizeBefore + 1, payees.size());
+
+        database.deletePayee(samplePayee);
+
+        payees = database.getAllPayees();
+        assertEquals(sizeBefore, payees.size());
+
+        List<Integer> ids = payees.stream().map(Payee::getId).collect(Collectors.toList());
+
+        assertFalse(ids.contains(samplePayee.getId()));
+    }
+
+    @Test
+    public void editPayee() throws Exception {
+        database.insertPayee(samplePayee);
+
+        List<Payee> payees = database.getAllPayees();
+        Payee toEdit = payees.get(0);
+        int originalId = toEdit.getId();
+
+        toEdit.setName("New Name");
+        database.editPayee(toEdit);
+
+        payees = database.getAllPayees();
+
+        Payee editedPayee = null;
+
+        for (Payee p : payees) {
+            if (p.getId() == originalId) editedPayee = p;
+        }
+        if (editedPayee == null) fail();
+
+        assertEquals("New Name", editedPayee.getName());
+        assertEquals(originalId, editedPayee.getId());
+    }
+
+    @Test
+    public void insertNote() throws Exception {
+        int sizeBefore = database.getAllNotes().size();
+
+        database.insertNote(sampleNote);
+        List<Note> notesAfterInsertion = database.getAllNotes();
+
+        assertEquals(sizeBefore + 1, notesAfterInsertion.size());
+
+        assertEquals(sizeBefore + 1, notesAfterInsertion.size());
+
+        Note insertedNote = null;
+
+        for (Note n : notesAfterInsertion) {
+            if (n.getNoteText().equals(sampleNote.getNoteText()) && n.getTransactionId() == sampleNote.getTransactionId())
+                insertedNote = n;
+        }
+
+        assertNotNull(insertedNote); //Already tested all fields as part of the search...
+    }
+
+    @Test
+    public void deleteNote() throws Exception {
+        Note testNote = new Note(5678, "This is a test note");
+        database.insertNote(testNote);
+
+        List<Note> notesBeforeDeletion = database.getAllNotes();
+
+        database.deleteNote(testNote);
+
+        List<Note> notesAfterDeletion = database.getAllNotes();
+
+        assertEquals(notesBeforeDeletion.size() - 1, notesAfterDeletion.size());
+
+        List<Integer> transIds = notesAfterDeletion.stream().map(Note::getTransactionId).collect(Collectors.toList());
+
+        assertFalse(transIds.contains(testNote.getTransactionId()));
+    }
+
+    @Test
+    public void editNote() throws Exception {
+        Note testNote = new Note(1234, "A note to test");
+        database.insertNote(testNote); //make sure there is at least one
+
+        List<Note> notes = database.getAllNotes();
+        Note noteToEdit = notes.get(0); //arbitrary
+
+        int originalTransactionId = noteToEdit.getTransactionId();
+        String textToSet = "This is edited text!";
+        noteToEdit.setNoteText(textToSet);
+
+        database.editNote(noteToEdit);
+
+        notes = database.getAllNotes();
+
+        Note editedNote = null;
+        for (Note n : notes) {
+            if (n.getNoteText().equals(noteToEdit.getNoteText()) && n.getTransactionId() == originalTransactionId) {
+                editedNote = n;
+            }
+        }
+
+        assertNotNull(editedNote); //already tested all fields in the loop above
+    }
+
+    @Test
+    public void insertType() throws Exception {
+        int sizeBeforeInsert = database.getAllTypes().size();
+
+        database.insertType(sampleType);
+
+        List<Type> typesAfterInsert = database.getAllTypes();
+        assertEquals(sizeBeforeInsert + 1, typesAfterInsert.size());
+
+        Type insertedType = null;
+        for (Type t : typesAfterInsert) {
+            if (t.getId() == sampleType.getId()) insertedType = t;
+        }
+        if (insertedType == null) fail();
+
+        assertEquals(sampleType.getId(), insertedType.getId());
+        assertEquals(sampleType.getName(), insertedType.getName());
+        assertEquals(sampleType.getDescription(), insertedType.getDescription());
+    }
+
+    @Test
+    public void deleteType() throws Exception {
+        database.insertType(sampleType);
+        database.insertType(sampleType2);
+
+        List<Type> typesBeforeDelete = database.getAllTypes();
+        int sizeBeforeDelete = typesBeforeDelete.size();
+
+
+        int deletedId = typesBeforeDelete.get(0).getId();
+        database.deleteType(typesBeforeDelete.get(0)); //arbitrary
+
+        List<Type> typesAfterDelete = database.getAllTypes();
+        assertEquals(sizeBeforeDelete - 1, typesAfterDelete.size());
+
+        List<Integer> idsAfterDelete = typesAfterDelete.stream().map(Type::getId).collect(Collectors.toList());
+
+        assertFalse(idsAfterDelete.contains(deletedId));
+    }
+
+    @Test
+    public void editType() throws Exception {
+        database.insertType(sampleType);
+
+        List<Type> types = database.getAllTypes();
+        int sizeBeforeEdit = types.size();
+
+        Type typeToEdit = types.get(0);
+        int idBeforeEdit = typeToEdit.getId();
+
+        typeToEdit.setName("ABCD");
+        typeToEdit.setDescription("1234");
+
+        database.editType(typeToEdit);
+
+        types = database.getAllTypes();
+        assertEquals(sizeBeforeEdit, types.size());
+
+        Type editedType = null;
+        for (Type t : types) {
+            if (t.getId() == idBeforeEdit) editedType = t;
+        }
+        if (editedType == null) fail();
+
+        assertEquals(idBeforeEdit, editedType.getId());
+        assertEquals("ABCD", editedType.getName());
+        assertEquals("1234", editedType.getDescription());
+    }
+
+    @Test
+    public void insertTag() throws Exception {
+        List<Tag> tagsBeforeInsertion = database.getAllTags();
+
+        database.insertTag(sampleTag);
+
+        List<Tag> tagsAfterInsertion = database.getAllTags();
+
+        Tag insertedTag = null;
+        for (Tag t : tagsAfterInsertion) {
+            if (t.getId() == sampleTag.getId()) insertedTag = t;
+        }
+        if (insertedTag == null) fail();
+
+        assertEquals(tagsBeforeInsertion.size() + 1, tagsAfterInsertion.size());
+        assertEquals(sampleTag.getId(), insertedTag.getId());
+        assertEquals(sampleTag.getName(), insertedTag.getName());
+    }
+
+    @Test
+    public void deleteTag() throws Exception {
+        database.insertTag(sampleTag);
+        database.insertTag(sampleTag2); //make sure there are some tags in the db
+
+        List<Tag> tagsBeforeDeletion = database.getAllTags();
+        Tag tagToDelete = tagsBeforeDeletion.get(0);
+        database.deleteTag(tagToDelete);
+
+        List<Tag> tagsAfterDeletion = database.getAllTags();
+
+        //pull out ids
+        List<Integer> ids = tagsAfterDeletion.stream().map(Tag::getId).collect(Collectors.toList());
+
+        assertEquals(tagsBeforeDeletion.size() - 1, tagsAfterDeletion.size());
+        assertFalse(ids.contains(tagToDelete.getId()));
+    }
+
+    @Test
+    public void editTag() throws Exception {
+        database.insertTag(sampleTag2);
+
+        List<Tag> tags = database.getAllTags();
+        Tag tagToEdit = tags.get(0);
+
+        String textToSet = "This is edited text!";
+        tagToEdit.setDescription(textToSet);
+
+        database.editTag(tagToEdit);
+
+        tags = database.getAllTags();
+        Tag editedTag = null;
+        for (Tag t : tags) {
+            if (t.getId() == tagToEdit.getId()) editedTag = t;
+        }
+        if (editedTag == null) fail();
+
+        assertEquals(textToSet, editedTag.getDescription());
+        assertEquals(tagToEdit.getId(), editedTag.getId());
+    }
+
+    @AfterClass
+    public static void afterTests() throws Exception {
+        database.shutdown();
+
+        Path dbPath = Paths.get("src/test/resources/test.mv.db");
+        Files.delete(dbPath);
+    }
+}

--- a/src/test/java/ledger/database/storage/H2DatabaseTest.java
+++ b/src/test/java/ledger/database/storage/H2DatabaseTest.java
@@ -36,7 +36,7 @@ public class H2DatabaseTest {
 
     @BeforeClass
     public static void setupDatabase() throws Exception {
-        database = new H2Database("./src/test/resources/testH2");
+        database = new H2Database("./src/test/resources/testH2", "password");
     }
 
     @Before

--- a/src/test/java/ledger/database/storage/H2DatabaseTest.java
+++ b/src/test/java/ledger/database/storage/H2DatabaseTest.java
@@ -3,7 +3,6 @@ package ledger.database.storage;
 import ledger.database.IDatabase;
 import ledger.database.enity.*;
 import ledger.database.storage.SQL.H2.H2Database;
-import ledger.database.storage.SQL.SQLite.SQLiteDatabase;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;
@@ -33,10 +32,11 @@ public class H2DatabaseTest {
     private static Tag sampleTag2;
     private static Note sampleNote;
     private static Note sampleNote2;
+    private static Note sampleNote3;
 
     @BeforeClass
     public static void setupDatabase() throws Exception {
-        database = new H2Database("./src/test/resources/test.db");
+        database = new H2Database("./src/test/resources/testH2");
     }
 
     @Before
@@ -49,13 +49,14 @@ public class H2DatabaseTest {
         sampleTag2 = new Tag("Electronics", "Money spent on electronics");
         sampleNote = new Note("This is a note");
         sampleNote2 = new Note("This is also a note");
+        sampleNote3 = new Note("This is also a note, ditto");
 
         ArrayList<Tag> sampleTagList = new ArrayList<>();
         sampleTagList.add(sampleTag);
 
         sampleTransaction1 = new Transaction(new Date(), sampleType, 4201, sampleAccount, samplePayee, true, sampleTagList, sampleNote);
-        sampleTransaction2 = new Transaction(new Date(), sampleType, 103, sampleAccount, samplePayee, true, sampleTagList, sampleNote);
-        sampleTransaction3 = new Transaction(new Date(), sampleType, 3304, sampleAccount, samplePayee, false, sampleTagList, sampleNote);
+        sampleTransaction2 = new Transaction(new Date(), sampleType, 103, sampleAccount, samplePayee, true, sampleTagList, sampleNote2);
+        sampleTransaction3 = new Transaction(new Date(), sampleType, 3304, sampleAccount, samplePayee, false, sampleTagList, sampleNote3);
 
         database.insertType(sampleType);
         database.insertType(sampleType2);
@@ -96,10 +97,15 @@ public class H2DatabaseTest {
         database.insertTransaction(sampleTransaction2);
         database.insertTransaction(sampleTransaction3);
 
+        ArrayList<Tag> sampleTagList = new ArrayList<>();
+        sampleTagList.add(sampleTag);
+        Transaction randomTrans = new Transaction(new Date(), sampleType2, 214, sampleAccount, samplePayee, false, sampleTagList, sampleNote3);
+        database.insertTransaction(randomTrans);
+
         List<Transaction> transactionsBeforeDelete = database.getAllTransactions();
         int countBeforeDelete = transactionsBeforeDelete.size();
 
-        Transaction transactionToDelete = transactionsBeforeDelete.get(0); //arbitrary
+        Transaction transactionToDelete = randomTrans;
         database.deleteTransaction(transactionToDelete);
 
         List<Transaction> transactionsAfterDelete = database.getAllTransactions();
@@ -192,9 +198,8 @@ public class H2DatabaseTest {
         List<Account> accountsBeforeDelete = database.getAllAccounts();
         int countBeforeDelete = accountsBeforeDelete.size();
 
-        Account accountToDelete = accountsBeforeDelete.get(0); //arbitrary
-        int deletedId = accountToDelete.getId();
-        database.deleteAccount(accountToDelete);
+        int deletedId = randomAcc.getId();
+        database.deleteAccount(randomAcc);
 
         List<Account> accountsAfterDelete = database.getAllAccounts();
         int countAfterDelete = accountsAfterDelete.size();
@@ -303,17 +308,15 @@ public class H2DatabaseTest {
     public void insertNote() throws Exception {
         int sizeBefore = database.getAllNotes().size();
 
-        database.insertNote(sampleNote);
+        database.insertTransaction(sampleTransaction3);
+        sampleNote3.setTransactionId(sampleTransaction3.getId());
         List<Note> notesAfterInsertion = database.getAllNotes();
 
         assertEquals(sizeBefore + 1, notesAfterInsertion.size());
-
-        assertEquals(sizeBefore + 1, notesAfterInsertion.size());
-
         Note insertedNote = null;
 
         for (Note n : notesAfterInsertion) {
-            if (n.getNoteText().equals(sampleNote.getNoteText()) && n.getTransactionId() == sampleNote.getTransactionId())
+            if (n.getNoteText().equals(sampleNote3.getNoteText()) && n.getTransactionId() == sampleNote3.getTransactionId())
                 insertedNote = n;
         }
 
@@ -323,7 +326,8 @@ public class H2DatabaseTest {
     @Test
     public void deleteNote() throws Exception {
         Note testNote = new Note(5678, "This is a test note");
-        database.insertNote(testNote);
+        this.sampleTransaction3.setNote(testNote);
+        database.insertTransaction(this.sampleTransaction3);
 
         List<Note> notesBeforeDeletion = database.getAllNotes();
 
@@ -341,10 +345,11 @@ public class H2DatabaseTest {
     @Test
     public void editNote() throws Exception {
         Note testNote = new Note(1234, "A note to test");
-        database.insertNote(testNote); //make sure there is at least one
+        this.sampleTransaction2.setNote(testNote);
+        database.insertTransaction(sampleTransaction2);
 
         List<Note> notes = database.getAllNotes();
-        Note noteToEdit = notes.get(0); //arbitrary
+        Note noteToEdit = testNote;
 
         int originalTransactionId = noteToEdit.getTransactionId();
         String textToSet = "This is edited text!";
@@ -386,15 +391,17 @@ public class H2DatabaseTest {
 
     @Test
     public void deleteType() throws Exception {
-        database.insertType(sampleType);
-        database.insertType(sampleType2);
+        Type testType3 = new Type("Testing Delete", "Used to test delete");
+        Type testType4 = new Type("Testing Delete2", "Also being used to test delete");
+
+        database.insertType(testType3);
+        database.insertType(testType4);
 
         List<Type> typesBeforeDelete = database.getAllTypes();
         int sizeBeforeDelete = typesBeforeDelete.size();
 
-
-        int deletedId = typesBeforeDelete.get(0).getId();
-        database.deleteType(typesBeforeDelete.get(0)); //arbitrary
+        int deletedId = testType3.getId();
+        database.deleteType(testType3);
 
         List<Type> typesAfterDelete = database.getAllTypes();
         assertEquals(sizeBeforeDelete - 1, typesAfterDelete.size());
@@ -458,8 +465,7 @@ public class H2DatabaseTest {
         database.insertTag(sampleTag2); //make sure there are some tags in the db
 
         List<Tag> tagsBeforeDeletion = database.getAllTags();
-        Tag tagToDelete = tagsBeforeDeletion.get(0);
-        database.deleteTag(tagToDelete);
+        database.deleteTag(sampleTag);
 
         List<Tag> tagsAfterDeletion = database.getAllTags();
 
@@ -467,7 +473,7 @@ public class H2DatabaseTest {
         List<Integer> ids = tagsAfterDeletion.stream().map(Tag::getId).collect(Collectors.toList());
 
         assertEquals(tagsBeforeDeletion.size() - 1, tagsAfterDeletion.size());
-        assertFalse(ids.contains(tagToDelete.getId()));
+        assertFalse(ids.contains(sampleTag.getId()));
     }
 
     @Test
@@ -497,7 +503,7 @@ public class H2DatabaseTest {
     public static void afterTests() throws Exception {
         database.shutdown();
 
-        Path dbPath = Paths.get("src/test/resources/test.mv.db");
+        Path dbPath = Paths.get("src/test/resources/testH2.mv.db");
         Files.delete(dbPath);
     }
 }

--- a/src/test/java/ledger/database/storage/SQLiteDatabaseTest.java
+++ b/src/test/java/ledger/database/storage/SQLiteDatabaseTest.java
@@ -385,15 +385,17 @@ public class SQLiteDatabaseTest {
 
     @Test
     public void deleteType() throws Exception {
-        database.insertType(sampleType);
-        database.insertType(sampleType2);
+        Type testType3 = new Type("Testing Delete", "Used to test delete");
+        Type testType4 = new Type("Testing Delete2", "Also being used to test delete");
+
+        database.insertType(testType3);
+        database.insertType(testType4);
 
         List<Type> typesBeforeDelete = database.getAllTypes();
         int sizeBeforeDelete = typesBeforeDelete.size();
 
-
-        int deletedId = typesBeforeDelete.get(0).getId();
-        database.deleteType(typesBeforeDelete.get(0)); //arbitrary
+        int deletedId = testType3.getId();
+        database.deleteType(testType3);
 
         List<Type> typesAfterDelete = database.getAllTypes();
         assertEquals(sizeBeforeDelete - 1, typesAfterDelete.size());

--- a/src/test/java/ledger/database/storage/SQLiteDatabaseTest.java
+++ b/src/test/java/ledger/database/storage/SQLiteDatabaseTest.java
@@ -2,6 +2,7 @@ package ledger.database.storage;
 
 import ledger.database.IDatabase;
 import ledger.database.enity.*;
+import ledger.database.storage.SQL.SQLite.SQLiteDatabase;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;

--- a/src/test/java/ledger/io/importer/ImporterTest.java
+++ b/src/test/java/ledger/io/importer/ImporterTest.java
@@ -2,7 +2,7 @@ package ledger.io.importer;
 
 import ledger.database.IDatabase;
 import ledger.database.enity.*;
-import ledger.database.storage.SQLiteDatabase;
+import ledger.database.storage.SQL.SQLite.SQLiteDatabase;
 import org.junit.AfterClass;
 import org.junit.Before;
 import org.junit.BeforeClass;

--- a/src/test/java/ledger/io/input/DuplicateDetectorTest.java
+++ b/src/test/java/ledger/io/input/DuplicateDetectorTest.java
@@ -2,7 +2,7 @@ package ledger.io.input;
 
 import ledger.database.IDatabase;
 import ledger.database.enity.*;
-import ledger.database.storage.SQLiteDatabase;
+import ledger.database.storage.SQL.SQLite.SQLiteDatabase;
 import ledger.exception.StorageException;
 import org.junit.*;
 

--- a/src/test/resources/README.md
+++ b/src/test/resources/README.md
@@ -1,3 +1,0 @@
-#Test Resources
-
-The only files in this folder should be resources required by our tests.


### PR DESCRIPTION
So there's a lot going on here, but its not terribly complicated. I'll try to explain so it makes a bit more sense. Encryption while still using SQLite was going to be a pain, so we abandoned it and switched to using [h2](http://www.h2database.com/html/main.html). H2 offers encryption build in (easy) and uses a subset of SQL for its query languages (pain the ass, but manageable). It also appears to be roughly 100x as fast.

I kept the SQLite files around, since support for multiple databases had been discussed. There's now a package for SQL databases. I abstracted some of the logic away from h2 and SQLite into interfaces for SQL databases in general.

Our database tests were copied over for h2. Some changes had to be made, as h2 is a little more picky about referential integrity. 

I can't wire it up to the UI yet, as that's not in master yet. That'll be as simple as editing the type query string and the type of the instantiation, so no worries.