### PR TITLE
[LED-95] Fixing Payee Duplicates

### DIFF
--- a/src/main/java/ledger/database/entity/Account.java
+++ b/src/main/java/ledger/database/entity/Account.java
@@ -76,7 +76,7 @@ public class Account implements IEntity {
      * Determines equality between this Account and another object
      *
      * @param o The object to compare to this Account
-     * @return True of this Account is equal to the provided object. False otherwise
+     * @return True if this Account is equal to the provided object. False otherwise
      */
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/ledger/database/entity/Payee.java
+++ b/src/main/java/ledger/database/entity/Payee.java
@@ -72,5 +72,23 @@ public class Payee implements IEntity {
         this.id = id;
     }
 
+    /**
+     * Determines equality between this Payee and another object
+     *
+     * @param o The object to compare to this Payee
+     * @return True if this Payee is equal to the provided object. False otherwise
+     */
+    @Override
+    public boolean equals(Object o) {
+
+        if (!(o instanceof Payee)) return false;
+
+        Payee otherPayee = ((Payee) o);
+
+        if(!this.getName().equals((otherPayee.getName()))) return false;
+        if(!this.getDescription().equals((otherPayee.getDescription()))) return false;
+        return true;
+    }
+
 }
 

--- a/src/main/java/ledger/database/entity/Payee.java
+++ b/src/main/java/ledger/database/entity/Payee.java
@@ -85,6 +85,8 @@ public class Payee implements IEntity {
 
         Payee otherPayee = ((Payee) o);
 
+        if(this.getName() == null && otherPayee.getName() != null) return false;
+        if(this.getDescription() == null && otherPayee.getDescription() != null) return false;
         if(this.getName() != null && !this.getName().equals((otherPayee.getName()))) return false;
         if(this.getDescription() != null && !this.getDescription().equals((otherPayee.getDescription()))) return false;
         return true;

--- a/src/main/java/ledger/database/entity/Payee.java
+++ b/src/main/java/ledger/database/entity/Payee.java
@@ -85,8 +85,8 @@ public class Payee implements IEntity {
 
         Payee otherPayee = ((Payee) o);
 
-        if(!this.getName().equals((otherPayee.getName()))) return false;
-        if(!this.getDescription().equals((otherPayee.getDescription()))) return false;
+        if(this.getName() != null && !this.getName().equals((otherPayee.getName()))) return false;
+        if(this.getDescription() != null && !this.getDescription().equals((otherPayee.getDescription()))) return false;
         return true;
     }
 

--- a/src/main/java/ledger/database/storage/SQL/ISQLDatabasePayee.java
+++ b/src/main/java/ledger/database/storage/SQL/ISQLDatabasePayee.java
@@ -17,15 +17,20 @@ public interface ISQLDatabasePayee extends ISQLiteDatabase {
     default void insertPayee(Payee payee) throws StorageException {
         try {
 
-            PreparedStatement checkIfExistsStmt = getDatabase().prepareStatement("SELECT " + PayeeTable.PAYEE_NAME +
+            PreparedStatement checkIfExistsStmt = getDatabase().prepareStatement("SELECT " + PayeeTable.PAYEE_ID + ", "
+                    + PayeeTable.PAYEE_NAME + ", " + PayeeTable.PAYEE_DESC +
                     " FROM " + PayeeTable.TABLE_NAME + " WHERE " + PayeeTable.PAYEE_NAME + "=?");
             checkIfExistsStmt.setString(1, payee.getName());
 
-            System.out.println(checkIfExistsStmt.toString());
-
-            checkIfExistsStmt.executeQuery();
-            ResultSet existingPayees = checkIfExistsStmt.getGeneratedKeys();
+            ResultSet existingPayees = checkIfExistsStmt.executeQuery();
             if (existingPayees.next()) {
+                int payeeID = existingPayees.getInt(PayeeTable.PAYEE_ID);
+                String payeeName = existingPayees.getString(PayeeTable.PAYEE_NAME);
+                String payeeDescription = existingPayees.getString(PayeeTable.PAYEE_DESC);
+
+                payee.setId(payeeID);
+                payee.setName(payeeName);
+                payee.setDescription(payeeDescription);
                 return;
             }
 

--- a/src/main/java/ledger/database/storage/SQL/ISQLDatabasePayee.java
+++ b/src/main/java/ledger/database/storage/SQL/ISQLDatabasePayee.java
@@ -16,6 +16,19 @@ public interface ISQLDatabasePayee extends ISQLiteDatabase {
     @Override
     default void insertPayee(Payee payee) throws StorageException {
         try {
+
+            PreparedStatement checkIfExistsStmt = getDatabase().prepareStatement("SELECT " + PayeeTable.PAYEE_NAME +
+                    " FROM " + PayeeTable.TABLE_NAME + " WHERE " + PayeeTable.PAYEE_NAME + "=?");
+            checkIfExistsStmt.setString(1, payee.getName());
+
+            System.out.println(checkIfExistsStmt.toString());
+
+            checkIfExistsStmt.executeQuery();
+            ResultSet existingPayees = checkIfExistsStmt.getGeneratedKeys();
+            if (existingPayees.next()) {
+                return;
+            }
+
             PreparedStatement stmt =
                     getDatabase().prepareStatement("INSERT INTO " + PayeeTable.TABLE_NAME +
                             " (" + PayeeTable.PAYEE_NAME +

--- a/src/main/java/ledger/database/storage/SQL/ISQLDatabaseTag.java
+++ b/src/main/java/ledger/database/storage/SQL/ISQLDatabaseTag.java
@@ -16,6 +16,19 @@ public interface ISQLDatabaseTag extends ISQLiteDatabase {
     @Override
     default void insertTag(Tag tag) throws StorageException {
         try {
+
+            PreparedStatement checkIfExistsStmt = getDatabase().prepareStatement("SELECT " + TagTable.TAG_NAME +
+                    " FROM " + TagTable.TABLE_NAME + " WHERE " + TagTable.TAG_NAME + "=?");
+            checkIfExistsStmt.setString(1, tag.getName());
+
+            System.out.println(checkIfExistsStmt.toString());
+
+            checkIfExistsStmt.executeQuery();
+            ResultSet existingPayees = checkIfExistsStmt.getGeneratedKeys();
+            if (existingPayees.next()) {
+                return;
+            }
+
             PreparedStatement stmt = getDatabase().prepareStatement("INSERT INTO " + TagTable.TABLE_NAME +
                     " (" + TagTable.TAG_NAME + ", " + TagTable.TAG_DESC + ") VALUES (?, ?)");
             stmt.setString(1, tag.getName());

--- a/src/main/java/ledger/database/storage/SQL/ISQLDatabaseTag.java
+++ b/src/main/java/ledger/database/storage/SQL/ISQLDatabaseTag.java
@@ -3,6 +3,7 @@ package ledger.database.storage.SQL;
 import ledger.database.entity.Tag;
 import ledger.database.storage.SQL.SQLite.ISQLiteDatabase;
 import ledger.database.storage.table.TagTable;
+import ledger.database.storage.table.TagToTransTable;
 import ledger.exception.StorageException;
 
 import java.sql.PreparedStatement;
@@ -17,15 +18,20 @@ public interface ISQLDatabaseTag extends ISQLiteDatabase {
     default void insertTag(Tag tag) throws StorageException {
         try {
 
-            PreparedStatement checkIfExistsStmt = getDatabase().prepareStatement("SELECT " + TagTable.TAG_NAME +
-                    " FROM " + TagTable.TABLE_NAME + " WHERE " + TagTable.TAG_NAME + "=?");
+            PreparedStatement checkIfExistsStmt = getDatabase().prepareStatement("SELECT " + TagTable.TAG_ID + ", " + TagTable.TAG_NAME +
+                    ", " + TagTable.TAG_DESC + " FROM " + TagTable.TABLE_NAME + " WHERE " + TagTable.TAG_NAME + "=?");
             checkIfExistsStmt.setString(1, tag.getName());
 
-            System.out.println(checkIfExistsStmt.toString());
+            ResultSet existingTags = checkIfExistsStmt.executeQuery();
+            if (existingTags.next()) {
+                int id = existingTags.getInt(TagTable.TAG_ID);
+                String name = existingTags.getString(TagTable.TAG_NAME);
+                String description = existingTags.getString(TagTable.TAG_DESC);
 
-            checkIfExistsStmt.executeQuery();
-            ResultSet existingPayees = checkIfExistsStmt.getGeneratedKeys();
-            if (existingPayees.next()) {
+                tag.setId(id);
+                tag.setName(name);
+                tag.setDescription(description);
+
                 return;
             }
 
@@ -48,6 +54,11 @@ public interface ISQLDatabaseTag extends ISQLiteDatabase {
     @Override
     default void deleteTag(Tag tag) throws StorageException {
         try {
+            PreparedStatement tttsDelete = getDatabase().prepareStatement("DELETE FROM " + TagToTransTable.TABLE_NAME +
+                " WHERE " + TagToTransTable.TTTS_TAG_ID + "=?");
+            tttsDelete.setInt(1, tag.getId());
+            tttsDelete.executeUpdate();
+
             PreparedStatement stmt = getDatabase().prepareStatement("DELETE FROM " + TagTable.TABLE_NAME +
                     " WHERE " + TagTable.TAG_ID + " = ?");
             stmt.setInt(1, tag.getId());
@@ -94,7 +105,7 @@ public interface ISQLDatabaseTag extends ISQLiteDatabase {
             }
             return tags;
         } catch (java.sql.SQLException e) {
-            throw new StorageException("Error while getting all notes", e);
+            throw new StorageException("Error while getting all tags", e);
         }
     }
 

--- a/src/test/java/ledger/database/storage/EntityTests.java
+++ b/src/test/java/ledger/database/storage/EntityTests.java
@@ -1,0 +1,29 @@
+package ledger.database.storage;
+
+import ledger.database.entity.Payee;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+/**
+ * Created by Jesse Shellabarger on 11/8/2016.
+ */
+public class EntityTests {
+
+    @Test
+    public void testPayeeEquals() {
+        Payee p1 = new Payee("name", "Description");
+        Payee p2 = new Payee("name", "Description");
+
+        assertEquals(p1, p2);
+
+        p2.setName("Different Name");
+
+        assertNotEquals(p1, p2);
+
+        Payee nullPayee = new Payee(null, null);
+
+        assertEquals(nullPayee, nullPayee);
+    }
+}

--- a/src/test/java/ledger/database/storage/H2DatabaseTest.java
+++ b/src/test/java/ledger/database/storage/H2DatabaseTest.java
@@ -243,7 +243,8 @@ public class H2DatabaseTest {
     public void insertPayee() throws Exception {
         int sizeBefore = database.getAllPayees().size();
 
-        database.insertPayee(samplePayee);
+        Payee testPayee = new Payee("test", "");
+        database.insertPayee(testPayee);
 
         List<Payee> payees = database.getAllPayees();
         assertEquals(sizeBefore + 1, payees.size());
@@ -251,14 +252,38 @@ public class H2DatabaseTest {
         Payee insertedPayee = null;
 
         for (Payee p : payees) {
-            if (p.getId() == samplePayee.getId()) insertedPayee = p;
+            if (p.getId() == testPayee.getId()) insertedPayee = p;
         }
 
         if (insertedPayee == null) fail();
 
-        assertEquals(samplePayee.getId(), insertedPayee.getId());
-        assertEquals(samplePayee.getName(), insertedPayee.getName());
-        assertEquals(samplePayee.getDescription(), insertedPayee.getDescription());
+        assertEquals(testPayee.getId(), insertedPayee.getId());
+        assertEquals(testPayee.getName(), insertedPayee.getName());
+        assertEquals(testPayee.getDescription(), insertedPayee.getDescription());
+    }
+
+    @Test
+    public void insertPayeeDuplicate() throws Exception {
+        int sizeBefore = database.getAllPayees().size();
+
+        Payee testPayee = new Payee("testInsertPayeeDupes", "");
+        database.insertPayee(testPayee);
+        database.insertPayee(testPayee);
+
+        List<Payee> payees = database.getAllPayees();
+        assertEquals(sizeBefore + 1, payees.size());
+
+        Payee insertedPayee = null;
+
+        for (Payee p : payees) {
+            if (p.getId() == testPayee.getId()) insertedPayee = p;
+        }
+
+        if (insertedPayee == null) fail();
+
+        assertEquals(testPayee.getId(), insertedPayee.getId());
+        assertEquals(testPayee.getName(), insertedPayee.getName());
+        assertEquals(testPayee.getDescription(), insertedPayee.getDescription());
     }
 
     @Test
@@ -444,19 +469,41 @@ public class H2DatabaseTest {
     public void insertTag() throws Exception {
         List<Tag> tagsBeforeInsertion = database.getAllTags();
 
-        database.insertTag(sampleTag);
+        Tag testTag = new Tag("testInsertTag", "");
+        database.insertTag(testTag);
 
         List<Tag> tagsAfterInsertion = database.getAllTags();
 
         Tag insertedTag = null;
         for (Tag t : tagsAfterInsertion) {
-            if (t.getId() == sampleTag.getId()) insertedTag = t;
+            if (t.getId() == testTag.getId()) insertedTag = t;
         }
         if (insertedTag == null) fail();
 
         assertEquals(tagsBeforeInsertion.size() + 1, tagsAfterInsertion.size());
-        assertEquals(sampleTag.getId(), insertedTag.getId());
-        assertEquals(sampleTag.getName(), insertedTag.getName());
+        assertEquals(testTag.getId(), insertedTag.getId());
+        assertEquals(testTag.getName(), insertedTag.getName());
+    }
+
+    @Test
+    public void insertTagDuplicate() throws Exception {
+        List<Tag> tagsBeforeInsertion = database.getAllTags();
+
+        Tag testTag = new Tag("testInsertTagDupes", "");
+        database.insertTag(testTag);
+        database.insertTag(testTag);
+
+        List<Tag> tagsAfterInsertion = database.getAllTags();
+
+        Tag insertedTag = null;
+        for (Tag t : tagsAfterInsertion) {
+            if (t.getId() == testTag.getId()) insertedTag = t;
+        }
+        if (insertedTag == null) fail();
+
+        assertEquals(tagsBeforeInsertion.size() + 1, tagsAfterInsertion.size());
+        assertEquals(testTag.getId(), insertedTag.getId());
+        assertEquals(testTag.getName(), insertedTag.getName());
     }
 
     @Test

--- a/src/test/java/ledger/database/storage/SQLiteDatabaseTest.java
+++ b/src/test/java/ledger/database/storage/SQLiteDatabaseTest.java
@@ -237,7 +237,8 @@ public class SQLiteDatabaseTest {
     public void insertPayee() throws Exception {
         int sizeBefore = database.getAllPayees().size();
 
-        database.insertPayee(samplePayee);
+        Payee testPayee = new Payee("test", "");
+        database.insertPayee(testPayee);
 
         List<Payee> payees = database.getAllPayees();
         assertEquals(sizeBefore + 1, payees.size());
@@ -245,14 +246,38 @@ public class SQLiteDatabaseTest {
         Payee insertedPayee = null;
 
         for (Payee p : payees) {
-            if (p.getId() == samplePayee.getId()) insertedPayee = p;
+            if (p.getId() == testPayee.getId()) insertedPayee = p;
         }
 
         if (insertedPayee == null) fail();
 
-        assertEquals(samplePayee.getId(), insertedPayee.getId());
-        assertEquals(samplePayee.getName(), insertedPayee.getName());
-        assertEquals(samplePayee.getDescription(), insertedPayee.getDescription());
+        assertEquals(testPayee.getId(), insertedPayee.getId());
+        assertEquals(testPayee.getName(), insertedPayee.getName());
+        assertEquals(testPayee.getDescription(), insertedPayee.getDescription());
+    }
+
+    @Test
+    public void insertPayeeDuplicate() throws Exception {
+        int sizeBefore = database.getAllPayees().size();
+
+        Payee testPayee = new Payee("testPayeeDupes", "");
+        database.insertPayee(testPayee);
+        database.insertPayee(testPayee);
+
+        List<Payee> payees = database.getAllPayees();
+        assertEquals(sizeBefore + 1, payees.size());
+
+        Payee insertedPayee = null;
+
+        for (Payee p : payees) {
+            if (p.getId() == testPayee.getId()) insertedPayee = p;
+        }
+
+        if (insertedPayee == null) fail();
+
+        assertEquals(testPayee.getId(), insertedPayee.getId());
+        assertEquals(testPayee.getName(), insertedPayee.getName());
+        assertEquals(testPayee.getDescription(), insertedPayee.getDescription());
     }
 
     @Test
@@ -438,19 +463,41 @@ public class SQLiteDatabaseTest {
     public void insertTag() throws Exception {
         List<Tag> tagsBeforeInsertion = database.getAllTags();
 
-        database.insertTag(sampleTag);
+        Tag testTag = new Tag("testInsertTag", "");
+        database.insertTag(testTag);
 
         List<Tag> tagsAfterInsertion = database.getAllTags();
 
         Tag insertedTag = null;
         for (Tag t : tagsAfterInsertion) {
-            if (t.getId() == sampleTag.getId()) insertedTag = t;
+            if (t.getId() == testTag.getId()) insertedTag = t;
         }
         if (insertedTag == null) fail();
 
         assertEquals(tagsBeforeInsertion.size() + 1, tagsAfterInsertion.size());
-        assertEquals(sampleTag.getId(), insertedTag.getId());
-        assertEquals(sampleTag.getName(), insertedTag.getName());
+        assertEquals(testTag.getId(), insertedTag.getId());
+        assertEquals(testTag.getName(), insertedTag.getName());
+    }
+
+    @Test
+    public void insertTagDuplicate() throws Exception {
+        List<Tag> tagsBeforeInsertion = database.getAllTags();
+
+        Tag testTag = new Tag("test", "");
+        database.insertTag(testTag);
+        database.insertTag(testTag);
+
+        List<Tag> tagsAfterInsertion = database.getAllTags();
+
+        Tag insertedTag = null;
+        for (Tag t : tagsAfterInsertion) {
+            if (t.getId() == testTag.getId()) insertedTag = t;
+        }
+        if (insertedTag == null) fail();
+
+        assertEquals(tagsBeforeInsertion.size() + 1, tagsAfterInsertion.size());
+        assertEquals(testTag.getId(), insertedTag.getId());
+        assertEquals(testTag.getName(), insertedTag.getName());
     }
 
     @Test


### PR DESCRIPTION
Ignore the wrong branch name, it's a struggle tonight.

- Fixed the payee boxes in the transaction table to not contain duplicate payees. 
- Fixed DB backend to not insert multiple of the same payee/tag
- fixed our tests to not suck (or suck less)
- wrote tests for this feature