### PR TITLE
[LED-96] Implemented embedded date picker

### DIFF
--- a/src/main/java/ledger/user_interface/ui_models/TransactionModel.java
+++ b/src/main/java/ledger/user_interface/ui_models/TransactionModel.java
@@ -5,6 +5,9 @@ import ledger.database.entity.Tag;
 import ledger.database.entity.Transaction;
 import ledger.database.entity.Type;
 
+import java.time.LocalDate;
+import java.time.ZoneId;
+import java.util.Date;
 import java.util.List;
 
 /**
@@ -15,7 +18,7 @@ public class TransactionModel {
 
     // Use TransactionModel
     private String amount;
-    private String date;
+    private LocalDate date;
     private String tagNames;
 
     // Use comboboxes and StringConverters
@@ -32,9 +35,10 @@ public class TransactionModel {
         String cents = amountInCents.substring(amountInCents.length() - 2, amountInCents.length());
         this.amount = "$" + dollars + "." + cents;
         if (transaction.getDate() != null) {
-            this.date = transaction.getDate().toString();
+            LocalDate date = transaction.getDate().toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
+            this.date = date;
         } else {
-            this.date = "";
+            this.date = null;
         }
         this.tagNames = "";
         if (transaction.getTagList() != null) {
@@ -75,11 +79,11 @@ public class TransactionModel {
         this.amount = amount;
     }
 
-    public String getDate() {
+    public LocalDate getDate() {
         return date;
     }
 
-    public void setDate(String date) {
+    public void setDate(LocalDate date) {
         this.date = date;
     }
 

--- a/src/main/java/ledger/user_interface/utils/LocalDateTableCell.java
+++ b/src/main/java/ledger/user_interface/utils/LocalDateTableCell.java
@@ -1,0 +1,111 @@
+package ledger.user_interface.utils;
+
+/**
+ * Created by Tayler How on 11/6/2016.
+ */
+
+/*
+ * Copyright 2014 michael-simons.eu.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+        import java.time.LocalDate;
+        import java.time.format.DateTimeFormatter;
+        import java.util.Optional;
+        import javafx.beans.binding.Bindings;
+        import javafx.beans.value.ChangeListener;
+        import javafx.beans.value.ObservableValue;
+        import javafx.scene.control.ContentDisplay;
+        import javafx.scene.control.DatePicker;
+        import javafx.scene.control.TableCell;
+        import javafx.scene.control.TableColumn;
+        import javafx.scene.control.TableView;
+        import javafx.util.StringConverter;
+
+        import static java.time.format.FormatStyle.MEDIUM;
+
+/**
+ * Renderes a localized LocalDate
+ *
+ * @author Michael J. Simons, 2014-10-17
+ * @param <T>
+ */
+public class LocalDateTableCell<T> extends TableCell<T, LocalDate> {
+    private static final DateTimeFormatter formatter = DateTimeFormatter.ofLocalizedDate(MEDIUM);
+    private final DatePicker datePicker;
+
+    public LocalDateTableCell(TableColumn<T, LocalDate> column) {
+        this.datePicker = new DatePicker();
+        this.datePicker.setConverter(new StringConverter<LocalDate>() {
+            @Override
+            public String toString(LocalDate object) {
+                String rv = null;
+                if(object != null) {
+                    rv = formatter.format(object);
+                }
+                return rv;
+            }
+
+            @Override
+            public LocalDate fromString(String string) {
+                LocalDate rv = null;
+                if(!Optional.ofNullable(string).orElse("").isEmpty()) {
+                    rv = LocalDate.parse(string, formatter);
+                }
+                return rv;
+            }
+        });
+        // Manage editing
+        this.datePicker.getEditor().focusedProperty().addListener((observable, oldValue, newValue) -> {
+            if(newValue) {
+                final TableView<T> tableView = getTableView();
+                tableView.getSelectionModel().select(getTableRow().getIndex());
+                tableView.edit(tableView.getSelectionModel().getSelectedIndex(), column);
+            }
+        });
+        this.datePicker.valueProperty().addListener((observable, oldValue, newValue) -> {
+            if(isEditing()) {
+                commitEdit(newValue);
+            }
+        });
+
+        // Bind this cells editable property to the whole column
+        editableProperty().bind(column.editableProperty());
+        // and then use this to configure the date picker
+        contentDisplayProperty().bind(Bindings
+                .when(editableProperty())
+                .then(ContentDisplay.GRAPHIC_ONLY)
+                .otherwise(ContentDisplay.TEXT_ONLY)
+        );
+    }
+
+    @Override
+    protected void updateItem(LocalDate item, boolean empty) {
+        super.updateItem(item, empty);
+
+        if(empty) {
+            setText(null);
+            setGraphic(null);
+        } else {
+            // Datepicker can handle null values
+            this.datePicker.setValue(item);
+            setGraphic(this.datePicker);
+            if(item == null) {
+                setText(null);
+            } else {
+                setText(formatter.format(item));
+            }
+        }
+    }
+}

--- a/src/main/java/ledger/user_interface/utils/LocalDateTableCell.java
+++ b/src/main/java/ledger/user_interface/utils/LocalDateTableCell.java
@@ -20,26 +20,25 @@ package ledger.user_interface.utils;
  * limitations under the License.
  */
 
-        import java.time.LocalDate;
-        import java.time.format.DateTimeFormatter;
-        import java.util.Optional;
-        import javafx.beans.binding.Bindings;
-        import javafx.beans.value.ChangeListener;
-        import javafx.beans.value.ObservableValue;
-        import javafx.scene.control.ContentDisplay;
-        import javafx.scene.control.DatePicker;
-        import javafx.scene.control.TableCell;
-        import javafx.scene.control.TableColumn;
-        import javafx.scene.control.TableView;
-        import javafx.util.StringConverter;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.Optional;
 
-        import static java.time.format.FormatStyle.MEDIUM;
+import javafx.beans.binding.Bindings;
+import javafx.scene.control.ContentDisplay;
+import javafx.scene.control.DatePicker;
+import javafx.scene.control.TableCell;
+import javafx.scene.control.TableColumn;
+import javafx.scene.control.TableView;
+import javafx.util.StringConverter;
+
+import static java.time.format.FormatStyle.MEDIUM;
 
 /**
- * Renderes a localized LocalDate
+ * Renders a localized LocalDate
  *
- * @author Michael J. Simons, 2014-10-17
  * @param <T>
+ * @author Michael J. Simons, 2014-10-17
  */
 public class LocalDateTableCell<T> extends TableCell<T, LocalDate> {
     private static final DateTimeFormatter formatter = DateTimeFormatter.ofLocalizedDate(MEDIUM);
@@ -51,7 +50,7 @@ public class LocalDateTableCell<T> extends TableCell<T, LocalDate> {
             @Override
             public String toString(LocalDate object) {
                 String rv = null;
-                if(object != null) {
+                if (object != null) {
                     rv = formatter.format(object);
                 }
                 return rv;
@@ -60,7 +59,7 @@ public class LocalDateTableCell<T> extends TableCell<T, LocalDate> {
             @Override
             public LocalDate fromString(String string) {
                 LocalDate rv = null;
-                if(!Optional.ofNullable(string).orElse("").isEmpty()) {
+                if (!Optional.ofNullable(string).orElse("").isEmpty()) {
                     rv = LocalDate.parse(string, formatter);
                 }
                 return rv;
@@ -68,14 +67,14 @@ public class LocalDateTableCell<T> extends TableCell<T, LocalDate> {
         });
         // Manage editing
         this.datePicker.getEditor().focusedProperty().addListener((observable, oldValue, newValue) -> {
-            if(newValue) {
+            if (newValue) {
                 final TableView<T> tableView = getTableView();
                 tableView.getSelectionModel().select(getTableRow().getIndex());
                 tableView.edit(tableView.getSelectionModel().getSelectedIndex(), column);
             }
         });
         this.datePicker.valueProperty().addListener((observable, oldValue, newValue) -> {
-            if(isEditing()) {
+            if (isEditing()) {
                 commitEdit(newValue);
             }
         });
@@ -94,14 +93,14 @@ public class LocalDateTableCell<T> extends TableCell<T, LocalDate> {
     protected void updateItem(LocalDate item, boolean empty) {
         super.updateItem(item, empty);
 
-        if(empty) {
+        if (empty) {
             setText(null);
             setGraphic(null);
         } else {
             // Datepicker can handle null values
             this.datePicker.setValue(item);
             setGraphic(this.datePicker);
-            if(item == null) {
+            if (item == null) {
                 setText(null);
             } else {
                 setText(formatter.format(item));


### PR DESCRIPTION
I've implemented the embedded date picker for transaction dates.

Currently, the date picker is always present in the table, and when clicked on it goes into editing view (the whole calendar shows up). I've been tinkering with ways to get the table cells to display as plain text dates, but haven't figured it out yet. I figured I'd make a PR for this since the functionality is present and our sprint is coming to an end soon. Pull this code down and test it, please!

¡Muchas gracias!
