### PR TITLE
[LED-112] Implemented better error handling on data export

### DIFF
--- a/src/main/java/ledger/user_interface/ui_controllers/GenericPopupController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/GenericPopupController.java
@@ -21,7 +21,7 @@ public class GenericPopupController extends GridPane implements Initializable, I
     @FXML
     private Button okayBtn;
     @FXML
-    private Text popupTitle;
+    private Text title;
 
     private final static String pageLoc = "/fxml_files/GenericPopup.fxml";
     private String msg;
@@ -47,7 +47,7 @@ public class GenericPopupController extends GridPane implements Initializable, I
     @Override
     public void initialize(URL fxmlFileLocation, ResourceBundle resources) {
         this.errorText.setText(this.msg);
-        this.popupTitle.setText(this.windowTitle);
+        this.title.setText(this.windowTitle);
         this.okayBtn.setOnAction((event) -> close());
     }
 

--- a/src/main/java/ledger/user_interface/ui_controllers/IUIController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/IUIController.java
@@ -47,6 +47,7 @@ public interface IUIController {
             loader.load();
         } catch (IOException e) {
             System.out.println(errMsg + " : " + e);
+            e.printStackTrace();
         }
 
     }

--- a/src/main/java/ledger/user_interface/ui_controllers/MainPageController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/MainPageController.java
@@ -189,6 +189,7 @@ public class MainPageController extends GridPane implements Initializable, IUICo
         chooser.setInitialDirectory(new File(System.getProperty("user.home")));
 
         File saveLocation = chooser.showDialog(this.exportDataBtn.getScene().getWindow());
+        if (saveLocation == null) return;
         File currentDbFile = DbController.INSTANCE.getDbFile();
         String timeStamp = new SimpleDateFormat("yyyyMMddhhmm").format(new Date());
         String fileName = timeStamp + currentDbFile.getName();

--- a/src/main/java/ledger/user_interface/ui_controllers/PasswordPromptController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/PasswordPromptController.java
@@ -45,7 +45,7 @@ public class PasswordPromptController extends Pane implements IUIController, Ini
             DbController.INSTANCE.initialize(dbFile.getAbsolutePath(), this.password.getText());
         } catch (StorageException e) {
             loginSuccess = false;
-            this.setupErrorPopup("Unable to reconnect to database.", e);
+            this.setupErrorPopup("Incorrect Password", new Exception());
             e.getStackTrace();
         }
         if (loginSuccess) ((Stage) this.getScene().getWindow()).close();

--- a/src/main/java/ledger/user_interface/ui_controllers/PasswordPromptController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/PasswordPromptController.java
@@ -45,7 +45,7 @@ public class PasswordPromptController extends Pane implements IUIController, Ini
             DbController.INSTANCE.initialize(dbFile.getAbsolutePath(), this.password.getText());
         } catch (StorageException e) {
             loginSuccess = false;
-            this.setupErrorPopup("Incorrect Password", new Exception());
+            this.setupErrorPopup("Incorrect Password!\nPlease try again.", new Exception());
             e.getStackTrace();
         }
         if (loginSuccess) ((Stage) this.getScene().getWindow()).close();


### PR DESCRIPTION
Fixed three issues that i found

- Closing the FileChooser would cause a NPE. It didnt hurt anything, but we can run a little more efficiently by not throwing unnecessary exceptions
- An incorrect password verification would throw exceptions and put the user back into the app anyway. The user could use the app like normal (with exceptions being thrown on every action) but nothing would persist after logout
- The object name of the title text in GenericErrorPopup was previously changed in the fxml but not the controller. Caused some funky behavior.