### PR TITLE
[LED-130] Statistics UI

### DIFF
--- a/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
@@ -279,12 +279,11 @@ public class ExpenditureChartsController extends GridPane implements Initializab
         Map<String, Integer> tagNameToAmountSpent = new HashMap<>();
         for (Transaction t : filteredTransactions) {
             if (t.getTagList().isEmpty()) {
-                List<Tag> substituteTag = new ArrayList<>();
-                substituteTag.add(new Tag("Uncategorized", "Uncategorized"));
-                t.setTagList(substituteTag);
-            }
-            for (Tag tag : t.getTagList()) {
-                addToMapForPieChart(tagNameToAmountSpent, tag.getName(), t.getAmount());
+                addToMapForPieChart(tagNameToAmountSpent, "Uncategorized", t.getAmount());
+            } else {
+                for (Tag tag : t.getTagList()) {
+                    addToMapForPieChart(tagNameToAmountSpent, tag.getName(), t.getAmount());
+                }
             }
         }
         List<PieChart.Data> dataList = new ArrayList<>();

--- a/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
@@ -4,6 +4,7 @@ import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.chart.PieChart;
 import javafx.scene.chart.StackedBarChart;
+import javafx.scene.control.DatePicker;
 import javafx.scene.layout.GridPane;
 
 import java.net.URL;
@@ -15,7 +16,11 @@ import java.util.ResourceBundle;
 public class ExpenditureChartsController extends GridPane implements Initializable, IUIController {
 
     @FXML
-    private PieChart expenditurePieChart;
+    private AccountDropdown accountFilterDropdown;
+    @FXML
+    private DatePicker fromDateFilter;
+    @FXML
+    private DatePicker toDateFilter;
     @FXML
     private StackedBarChart expenditureBarChart;
 

--- a/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
@@ -278,6 +278,11 @@ public class ExpenditureChartsController extends GridPane implements Initializab
     private void createPieChart(List<Transaction> filteredTransactions) {
         Map<String, Integer> tagNameToAmountSpent = new HashMap<>();
         for (Transaction t : filteredTransactions) {
+            if (t.getTagList().isEmpty()) {
+                List<Tag> substituteTag = new ArrayList<>();
+                substituteTag.add(new Tag("Uncategorized", "Uncategorized"));
+                t.setTagList(substituteTag);
+            }
             for (Tag tag : t.getTagList()) {
                 addToMapForPieChart(tagNameToAmountSpent, tag.getName(), t.getAmount());
             }
@@ -312,7 +317,10 @@ public class ExpenditureChartsController extends GridPane implements Initializab
      * @param value value to add to existing value or empty map
      */
     private void addToMapForPieChart(Map map, String key, Integer value) {
-        if (!key.equals("") && value <= 0) {
+        if (value <= 0) {
+            if (key.equals("")) {
+                key = "Uncategorized";
+            }
             populateMap(map, key, value);
         }
     }

--- a/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
@@ -5,6 +5,7 @@ import javafx.fxml.Initializable;
 import javafx.scene.chart.LineChart;
 import javafx.scene.chart.PieChart;
 import javafx.scene.chart.StackedBarChart;
+import javafx.scene.control.Button;
 import javafx.scene.control.DatePicker;
 import javafx.scene.control.Label;
 import javafx.scene.layout.GridPane;
@@ -29,6 +30,8 @@ public class ExpenditureChartsController extends GridPane implements Initializab
     private Label displayLabel;
     @FXML
     private LineChart expendituresLineChart;
+    @FXML
+    private Button filterEnterButton;
 
     private final static String pageLoc = "/fxml_files/ExpenditureCharts.fxml";
 

--- a/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
@@ -277,6 +277,10 @@ public class ExpenditureChartsController extends GridPane implements Initializab
             // use absolute value here so it's not negative
             dataList.add(new PieChart.Data(tag, Math.abs(tagNameToAmountSpent.get(tag)) / 100));
         }
+        if (dataList.isEmpty()) {
+            this.setupErrorPopup("There's no data to be displayed!", new Exception());
+            return;
+        }
         ObservableList<PieChart.Data> pieChartData = FXCollections.observableArrayList(dataList);
         this.expendituresPieChart.setData(pieChartData);
         this.expendituresPieChart.setTitle("Expenditures by Category");

--- a/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
@@ -4,6 +4,7 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
+import javafx.scene.Node;
 import javafx.scene.chart.*;
 import javafx.scene.control.Button;
 import javafx.scene.control.DatePicker;
@@ -300,7 +301,7 @@ public class ExpenditureChartsController extends GridPane implements Initializab
         this.expendituresPieChart.setTitle("Expenditures by Category");
         this.expendituresPieChart.setVisible(true);
         int i = 0;
-        List<String> pieColors = Arrays.asList("red", "orange", "yellow", "green", "blue", "purple", "pink");
+        List<String> pieColors = Arrays.asList("red", "orange", "green", "blue", "purple", "pink", "yellow");
         for (PieChart.Data data : dataList) {
             data.getNode().setStyle("-fx-pie-color: " + pieColors.get(i % pieColors.size()) + ";");
             i++;

--- a/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
@@ -39,7 +39,7 @@ public class ExpenditureChartsController extends GridPane implements Initializab
     @FXML
     private PieChart expendituresPieChart;
     @FXML
-    private Label displayLabel;
+    private Label currentlyShowingLabel;
     @FXML
     private LineChart expendituresLineChart;
     @FXML
@@ -69,14 +69,15 @@ public class ExpenditureChartsController extends GridPane implements Initializab
     public void initialize(URL fxmlFileLocation, ResourceBundle resources) {
 
         this.filterEnterButton.setOnAction((event) -> {
-            Account accountSelected = accountFilterDropdown.getSelectedAccount();
-            LocalDate fromDateSelected = fromDateFilter.getValue();
-            LocalDate toDateSelected = toDateFilter.getValue();
+            Account accountSelected = this.accountFilterDropdown.getSelectedAccount();
+            LocalDate fromDateSelected = this.fromDateFilter.getValue();
+            LocalDate toDateSelected = this.toDateFilter.getValue();
             if (accountSelected == null && fromDateSelected == null && toDateSelected == null) {
                 this.setupErrorPopup("You must either select an account or a date range to continue!", new Exception());
                 return;
             }
             if ((accountSelected != null) && ((fromDateSelected == null) || (toDateSelected == null))) {
+                this.currentlyShowingLabel.setText("Currently showing expenditures for account: " + accountSelected.getName());
                 createBasedOnAccount(accountSelected);
             }
             if ((accountSelected == null) && (fromDateSelected != null) && (toDateSelected != null)) {
@@ -84,6 +85,7 @@ public class ExpenditureChartsController extends GridPane implements Initializab
                     this.setupErrorPopup("Ensure your dates are in chronological order!", new Exception());
                     return;
                 }
+                this.currentlyShowingLabel.setText("Currently showing expenditures for the above date range.");
                 createBasedOnDateRange(fromDateSelected, toDateSelected);
             }
             if ((accountSelected != null) && (fromDateSelected != null) && (toDateSelected != null)) {
@@ -91,6 +93,7 @@ public class ExpenditureChartsController extends GridPane implements Initializab
                     this.setupErrorPopup("Ensure your dates are in chronological order!", new Exception());
                     return;
                 }
+                this.currentlyShowingLabel.setText("Currently showing expenditures for account: " + accountSelected.getName() + " within the above date range.");
                 createBasedOnAccountAndDateRange(accountSelected, fromDateSelected, toDateSelected);
             }
         });
@@ -142,16 +145,16 @@ public class ExpenditureChartsController extends GridPane implements Initializab
             preorderedMonths.add(m);
         }
         preorderedMonths.sort((String o1, String o2) -> {
-                SimpleDateFormat s = new SimpleDateFormat("MMM");
-                Date s1 = null;
-                Date s2 = null;
-                try {
-                    s1 = s.parse(o1);
-                    s2 = s.parse(o2);
-                } catch (ParseException e) {
-                    e.printStackTrace();
-                }
-                return s1.compareTo(s2);
+            SimpleDateFormat s = new SimpleDateFormat("MMM");
+            Date s1 = null;
+            Date s2 = null;
+            try {
+                s1 = s.parse(o1);
+                s2 = s.parse(o2);
+            } catch (ParseException e) {
+                e.printStackTrace();
+            }
+            return s1.compareTo(s2);
         });
 
         XYChart.Series series = new XYChart.Series();
@@ -247,6 +250,7 @@ public class ExpenditureChartsController extends GridPane implements Initializab
         }
         ObservableList<PieChart.Data> pieChartData = FXCollections.observableArrayList(dataList);
         this.expendituresPieChart.setData(pieChartData);
+        this.expendituresPieChart.setTitle("Expenditures by Category");
         this.expendituresPieChart.setVisible(true);
     }
 

--- a/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
@@ -8,12 +8,17 @@ import javafx.scene.control.Button;
 import javafx.scene.control.DatePicker;
 import javafx.scene.control.Label;
 import javafx.scene.layout.GridPane;
+import ledger.controller.DbController;
+import ledger.controller.register.TaskWithReturn;
 import ledger.database.entity.Account;
+import ledger.database.entity.Transaction;
 
 import java.net.URL;
 import java.time.LocalDate;
 import java.util.Date;
+import java.util.List;
 import java.util.ResourceBundle;
+import java.util.concurrent.ExecutionException;
 
 /**
  * Controls how the charts render with user given information.
@@ -35,6 +40,7 @@ public class ExpenditureChartsController extends GridPane implements Initializab
     @FXML
     private Button filterEnterButton;
 
+    private List<Transaction> allTransactions;
     private final static String pageLoc = "/fxml_files/ExpenditureCharts.fxml";
 
     ExpenditureChartsController() {
@@ -83,16 +89,20 @@ public class ExpenditureChartsController extends GridPane implements Initializab
                 }
                 createBasedOnAccountAndDateRange(accountSelected, fromDateSelected, toDateSelected);
             }
-
         });
-
     }
 
     /**
      * Retrieves transactions from the database and sets field for use
      */
     private void getTransactions() {
-
+        TaskWithReturn<List<Transaction>> task = DbController.INSTANCE.getAllTransactions();
+        task.RegisterFailureEvent((e) -> {
+            setupErrorPopup("Error retrieving transactions.", new Exception());
+        });
+        task.startTask();
+        List<Transaction> allTransactions = task.waitForResult();
+        this.allTransactions = allTransactions;
     }
 
     /**

--- a/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
@@ -4,13 +4,11 @@ import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
-import javafx.scene.Scene;
 import javafx.scene.chart.*;
 import javafx.scene.control.Button;
 import javafx.scene.control.DatePicker;
 import javafx.scene.control.Label;
 import javafx.scene.layout.GridPane;
-import javafx.stage.Stage;
 import ledger.controller.DbController;
 import ledger.controller.register.TaskWithReturn;
 import ledger.database.entity.Account;
@@ -161,7 +159,7 @@ public class ExpenditureChartsController extends GridPane implements Initializab
      * Takes care of ordering the months chronologically and also handles the switch
      * from December to January in a new year
      *
-     * @param monthToYear HashMap that keeps references from each month to their respective year
+     * @param monthToYear      HashMap that keeps references from each month to their respective year
      * @param preorderedMonths Unordered list of months
      */
     private void orderMonthsAndYears(Map<String, Integer> monthToYear, List<String> preorderedMonths) {

--- a/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
@@ -3,7 +3,6 @@ package ledger.user_interface.ui_controllers;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
 import javafx.scene.chart.LineChart;
-import javafx.scene.chart.PieChart;
 import javafx.scene.chart.StackedBarChart;
 import javafx.scene.control.Button;
 import javafx.scene.control.DatePicker;
@@ -52,5 +51,10 @@ public class ExpenditureChartsController extends GridPane implements Initializab
      */
     @Override
     public void initialize(URL fxmlFileLocation, ResourceBundle resources) {
+
+        this.filterEnterButton.setOnAction((event) -> {
+
+        });
+
     }
 }

--- a/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
@@ -8,8 +8,11 @@ import javafx.scene.control.Button;
 import javafx.scene.control.DatePicker;
 import javafx.scene.control.Label;
 import javafx.scene.layout.GridPane;
+import ledger.database.entity.Account;
 
 import java.net.URL;
+import java.time.LocalDate;
+import java.util.Date;
 import java.util.ResourceBundle;
 
 /**
@@ -39,7 +42,7 @@ public class ExpenditureChartsController extends GridPane implements Initializab
     }
 
     /**
-     * Will be used to set up the charts on this page
+     * Is used to set up the charts on this page
      * <p>
      * Called to initialize a controller after its root element has been
      * completely processed.
@@ -53,8 +56,79 @@ public class ExpenditureChartsController extends GridPane implements Initializab
     public void initialize(URL fxmlFileLocation, ResourceBundle resources) {
 
         this.filterEnterButton.setOnAction((event) -> {
+            getTransactions();
+            setupExpenditureHistoryChart();
+
+            Account accountSelected = accountFilterDropdown.getSelectedAccount();
+            LocalDate fromDateSelected = fromDateFilter.getValue();
+            LocalDate toDateSelected = toDateFilter.getValue();
+            if (accountSelected.equals(null) && fromDateSelected.equals(null) && toDateSelected.equals(null)) {
+                this.setupErrorPopup("You must either select an Account or a date range to continue!", new Exception());
+                return;
+            }
+            if (!accountSelected.equals(null) && (fromDateSelected.equals(null) || toDateSelected.equals(null))) {
+                createBasedOnAccount(accountSelected);
+            }
+            if (accountSelected.equals(null) && !(fromDateSelected.equals(null) && toDateSelected.equals(null))) {
+                if (fromDateSelected.isAfter(toDateSelected)) {
+                    this.setupErrorPopup("Ensure your dates are in chronological order!", new Exception());
+                    return;
+                }
+                createBasedOnDateRange(fromDateSelected, toDateSelected);
+            }
+            if (!(accountSelected.equals(null) && fromDateSelected.equals(null) && toDateSelected.equals(null))) {
+                if (fromDateSelected.isAfter(toDateSelected)) {
+                    this.setupErrorPopup("Ensure your dates are in chronological order!", new Exception());
+                    return;
+                }
+                createBasedOnAccountAndDateRange(accountSelected, fromDateSelected, toDateSelected);
+            }
 
         });
+
+    }
+
+    /**
+     * Retrieves transactions from the database and sets field for use
+     */
+    private void getTransactions() {
+
+    }
+
+    /**
+     * Builds the line chart to show trends in amount spent over the last six months
+     */
+    private void setupExpenditureHistoryChart() {
+
+    }
+
+    /**
+     * Creates the stacked bar chart based on transactions in a specified account
+     *
+     * @param account the account to filter the transactions by
+     */
+    private void createBasedOnAccount(Account account) {
+
+    }
+
+    /**
+     * Creates the stacked bar chart based on transactions in a specified date range
+     *
+     * @param fromDate starting date to filter transactions by
+     * @param toDate ending date to filter transactions by
+     */
+    private void createBasedOnDateRange(LocalDate fromDate, LocalDate toDate) {
+
+    }
+
+    /**
+     * Creates the stacked bar chart based the transactions that exist in a specified account within a given date range
+     *
+     * @param account the account to filter the transactions by
+     * @param fromDate starting date to filter transactions by
+     * @param toDate ending date to filter transactions by
+     */
+    private void createBasedOnAccountAndDateRange(Account account, LocalDate fromDate, LocalDate toDate) {
 
     }
 }

--- a/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
@@ -133,17 +133,19 @@ public class ExpenditureChartsController extends GridPane implements Initializab
         this.expendituresLineChart.getYAxis().setAutoRanging(true);
 
         Map<String, Integer> monthToAmountSpent = new HashMap<>();
+        Map<String, Integer> monthToYear = new HashMap<>();
         for (Transaction t : filteredTransactions) {
             cal.setTime(t.getDate());
             String month = new DateFormatSymbols().getMonths()[cal.get(Calendar.MONTH)];
+            Integer year = cal.get(Calendar.YEAR);
+            monthToYear.put(month, year);
             addToMap(monthToAmountSpent, month, t.getAmount());
         }
 
         Set<String> months = monthToAmountSpent.keySet();
         List<String> preorderedMonths = new ArrayList<>();
-        for (String m : months) {
-            preorderedMonths.add(m);
-        }
+        preorderedMonths.addAll(months);
+
         preorderedMonths.sort((String o1, String o2) -> {
             SimpleDateFormat s = new SimpleDateFormat("MMM");
             Date s1 = null;
@@ -156,6 +158,24 @@ public class ExpenditureChartsController extends GridPane implements Initializab
             }
             return s1.compareTo(s2);
         });
+        List<String> monthsInNextYear = new ArrayList<>();
+        Integer lowestYear = 0;
+        for (int j = 0; j < preorderedMonths.size(); j++) {
+            if (j == 0) {
+                lowestYear = monthToYear.get(preorderedMonths.get(j));
+            } else if (monthToYear.get(preorderedMonths.get(j)) < lowestYear) {
+                lowestYear = monthToYear.get(preorderedMonths.get(j));
+            }
+        }
+        for (int i = 0; i < preorderedMonths.size(); i++) {
+            if (monthToYear.get(preorderedMonths.get(i)) > lowestYear) {
+                monthsInNextYear.add(preorderedMonths.get(i));
+            }
+        }
+        // takes the months in the next year out of the beginning of the list and tacks them on the end
+        preorderedMonths.removeAll(monthsInNextYear);
+        preorderedMonths.addAll(monthsInNextYear);
+
 
         XYChart.Series series = new XYChart.Series();
         for (String m : preorderedMonths) {

--- a/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
@@ -157,7 +157,7 @@ public class ExpenditureChartsController extends GridPane implements Initializab
             }
         }
 
-        populateTagMapAndCreatePieChart(filteredTransactions);
+        createPieChart(filteredTransactions);
     }
 
     /**
@@ -178,7 +178,7 @@ public class ExpenditureChartsController extends GridPane implements Initializab
             }
         }
 
-        populateTagMapAndCreatePieChart(filteredTransactions);
+        createPieChart(filteredTransactions);
     }
 
     /**
@@ -206,7 +206,7 @@ public class ExpenditureChartsController extends GridPane implements Initializab
             }
         }
 
-        populateTagMapAndCreatePieChart(filteredTransactions);
+        createPieChart(filteredTransactions);
     }
 
     /**
@@ -214,7 +214,7 @@ public class ExpenditureChartsController extends GridPane implements Initializab
      *
      * @param filteredTransactions transactions fitting the criteria of the filter
      */
-    private void populateTagMapAndCreatePieChart(List<Transaction> filteredTransactions) {
+    private void createPieChart(List<Transaction> filteredTransactions) {
         Map<Tag, Integer> tagToAmountSpent = new HashMap<>();
         for (Transaction t : filteredTransactions) {
             for (Tag tag : t.getTagList()) {

--- a/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
@@ -52,6 +52,7 @@ public class ExpenditureChartsController extends GridPane implements Initializab
         this.initController(pageLoc, this, "Error on expenditure chart page startup: ");
         getTransactions();
         setupExpenditureHistoryChart();
+        setupInitialPieChart();
     }
 
     /**
@@ -195,6 +196,13 @@ public class ExpenditureChartsController extends GridPane implements Initializab
         // takes the months in the next year out of the beginning of the list and tacks them on the end
         preorderedMonths.removeAll(monthsInNextYear);
         preorderedMonths.addAll(monthsInNextYear);
+    }
+
+    /**
+     * Sets up PieChart seen on initialization of expenditures screen. Data is loaded from all accounts.
+     */
+    private void setupInitialPieChart() {
+        createPieChart(this.allTransactions);
     }
 
     /**

--- a/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
@@ -23,6 +23,8 @@ import java.time.LocalDate;
 import java.time.ZoneId;
 import java.util.*;
 
+import static java.awt.Color.red;
+
 /**
  * Controls how the charts render with user given information.
  */
@@ -285,6 +287,12 @@ public class ExpenditureChartsController extends GridPane implements Initializab
         this.expendituresPieChart.setData(pieChartData);
         this.expendituresPieChart.setTitle("Expenditures by Category");
         this.expendituresPieChart.setVisible(true);
+        int i = 0;
+        List<String> pieColors = Arrays.asList("red", "orange", "yellow", "green", "blue", "purple", "pink");
+        for (PieChart.Data data : dataList) {
+            data.getNode().setStyle("-fx-pie-color: " + pieColors.get(i % pieColors.size()) + ";");
+            i++;
+        }
     }
 
     /**

--- a/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
@@ -2,6 +2,7 @@ package ledger.user_interface.ui_controllers;
 
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
+import javafx.scene.chart.LineChart;
 import javafx.scene.chart.PieChart;
 import javafx.scene.chart.StackedBarChart;
 import javafx.scene.control.DatePicker;
@@ -26,6 +27,8 @@ public class ExpenditureChartsController extends GridPane implements Initializab
     private StackedBarChart expenditureBarChart;
     @FXML
     private Label displayLabel;
+    @FXML
+    private LineChart expendituresLineChart;
 
     private final static String pageLoc = "/fxml_files/ExpenditureCharts.fxml";
 

--- a/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
@@ -234,20 +234,20 @@ public class ExpenditureChartsController extends GridPane implements Initializab
      * @param filteredTransactions transactions fitting the criteria of the filter
      */
     private void createPieChart(List<Transaction> filteredTransactions) {
-        Map<Tag, Integer> tagToAmountSpent = new HashMap<>();
+        Map<String, Integer> tagNameToAmountSpent = new HashMap<>();
         for (Transaction t : filteredTransactions) {
             for (Tag tag : t.getTagList()) {
-                addToMap(tagToAmountSpent, tag, t.getAmount());
+                addToMap(tagNameToAmountSpent, tag.getName(), t.getAmount());
             }
         }
         List<PieChart.Data> dataList = new ArrayList<>();
-        for (Tag t : tagToAmountSpent.keySet()) {
+        for (String tag : tagNameToAmountSpent.keySet()) {
             // use absolute value here so it's not negative
-            dataList.add(new PieChart.Data(t.getName(), Math.abs(tagToAmountSpent.get(t)) / 100));
+            dataList.add(new PieChart.Data(tag, Math.abs(tagNameToAmountSpent.get(tag)) / 100));
         }
         ObservableList<PieChart.Data> pieChartData = FXCollections.observableArrayList(dataList);
         this.expendituresPieChart.setData(pieChartData);
-        //TODO get pie chart to actually show up
+        this.expendituresPieChart.setVisible(true);
     }
 
     /**
@@ -258,14 +258,14 @@ public class ExpenditureChartsController extends GridPane implements Initializab
      * @param key   map key to check value
      * @param value value to add to existing value or empty map
      */
-    private void addToMap(Map map, Object key, Object value) {
+    private void addToMap(Map map, String key, Integer value) {
         if (!map.keySet().contains(key)) {
             map.put(key, value);
         } else {
             Integer existingAmount = (Integer) map.get(key);
             Integer newAmount = existingAmount;
-            if ((Integer) value < 0) {
-                newAmount += (Integer) value;
+            if (value < 0) {
+                newAmount += value;
             }
             map.put(key, newAmount);
         }

--- a/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
@@ -5,6 +5,7 @@ import javafx.fxml.Initializable;
 import javafx.scene.chart.PieChart;
 import javafx.scene.chart.StackedBarChart;
 import javafx.scene.control.DatePicker;
+import javafx.scene.control.Label;
 import javafx.scene.layout.GridPane;
 
 import java.net.URL;
@@ -23,6 +24,8 @@ public class ExpenditureChartsController extends GridPane implements Initializab
     private DatePicker toDateFilter;
     @FXML
     private StackedBarChart expenditureBarChart;
+    @FXML
+    private Label displayLabel;
 
     private final static String pageLoc = "/fxml_files/ExpenditureCharts.fxml";
 

--- a/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/ExpenditureChartsController.java
@@ -141,9 +141,7 @@ public class ExpenditureChartsController extends GridPane implements Initializab
         for (String m : months) {
             preorderedMonths.add(m);
         }
-        final Comparator<String> monthCompare = new Comparator<String>() {
-            @Override
-            public int compare(String o1, String o2) {
+        preorderedMonths.sort((String o1, String o2) -> {
                 SimpleDateFormat s = new SimpleDateFormat("MMM");
                 Date s1 = null;
                 Date s2 = null;
@@ -154,9 +152,7 @@ public class ExpenditureChartsController extends GridPane implements Initializab
                     e.printStackTrace();
                 }
                 return s1.compareTo(s2);
-            }
-        };
-        Collections.sort(preorderedMonths, monthCompare);
+        });
 
         XYChart.Series series = new XYChart.Series();
         for (String m : preorderedMonths) {

--- a/src/main/resources/fxml_files/ExpenditureCharts.fxml
+++ b/src/main/resources/fxml_files/ExpenditureCharts.fxml
@@ -87,12 +87,18 @@
                   <Font name="Calibri Light" size="18.0" />
                </font>
             </Text>
-            <Label text="Currently showing: " GridPane.columnSpan="4" GridPane.halignment="CENTER" GridPane.rowIndex="3">
+            <Label fx:id="currentlyShowingLabel" prefHeight="55.0" prefWidth="404.0" textAlignment="CENTER" wrapText="true" GridPane.columnSpan="4" GridPane.halignment="LEFT" GridPane.rowIndex="3" GridPane.rowSpan="2">
                <font>
                   <Font name="Calibri Light" size="18.0" />
                </font>
+               <GridPane.margin>
+                  <Insets left="20.0" right="10.0" />
+               </GridPane.margin>
             </Label>
-            <Button fx:id="filterEnterButton" mnemonicParsing="false" prefHeight="33.0" prefWidth="84.0" text="Enter" textAlignment="CENTER" GridPane.columnIndex="3" GridPane.halignment="CENTER" GridPane.rowIndex="4" />
+            <Button fx:id="filterEnterButton" mnemonicParsing="false" prefHeight="33.0" prefWidth="84.0" text="Enter" textAlignment="CENTER" GridPane.columnIndex="3" GridPane.halignment="CENTER" GridPane.rowIndex="4">
+               <GridPane.margin>
+                  <Insets bottom="15.0" left="70.0" />
+               </GridPane.margin></Button>
          </children>
          <padding>
             <Insets bottom="5.0" />
@@ -112,7 +118,7 @@
             <Insets top="10.0" />
          </GridPane.margin>
       </LineChart>
-      <PieChart fx:id="expendituresPieChart" title="Filtered Expenditures" GridPane.columnIndex="3" GridPane.columnSpan="4" GridPane.rowIndex="2" GridPane.rowSpan="5">
+      <PieChart fx:id="expendituresPieChart" GridPane.columnIndex="3" GridPane.columnSpan="4" GridPane.rowIndex="2" GridPane.rowSpan="5">
          <GridPane.margin>
             <Insets bottom="20.0" left="20.0" right="20.0" top="20.0" />
          </GridPane.margin>

--- a/src/main/resources/fxml_files/ExpenditureCharts.fxml
+++ b/src/main/resources/fxml_files/ExpenditureCharts.fxml
@@ -5,6 +5,7 @@
 <?import javafx.scene.chart.CategoryAxis?>
 <?import javafx.scene.chart.NumberAxis?>
 <?import javafx.scene.chart.StackedBarChart?>
+<?import javafx.scene.control.DatePicker?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.Pane?>
@@ -16,6 +17,7 @@
 <fx:root fx:id="mainBackground" maxHeight="800.0" maxWidth="1280.0" minHeight="800.0" minWidth="1280.0" prefHeight="800.0" prefWidth="1280.0" style="-fx-background-color: #ffffff;" type="GridPane" xmlns="http://javafx.com/javafx/8.0.101" xmlns:fx="http://javafx.com/fxml/1">
     <columnConstraints>
         <ColumnConstraints hgrow="SOMETIMES" maxWidth="200.0" minWidth="178.0" prefWidth="178.0" />
+      <ColumnConstraints hgrow="SOMETIMES" maxWidth="200.0" minWidth="178.0" prefWidth="178.0" />
         <ColumnConstraints hgrow="SOMETIMES" maxWidth="1048.0" minWidth="10.0" prefWidth="1034.0" />
         <ColumnConstraints hgrow="SOMETIMES" maxWidth="1048.0" minWidth="10.0" prefWidth="1034.0" />
         <ColumnConstraints hgrow="SOMETIMES" maxWidth="1048.0" minWidth="10.0" prefWidth="1034.0" />
@@ -25,15 +27,15 @@
     </columnConstraints>
     <rowConstraints>
         <RowConstraints maxHeight="40.0" minHeight="40.0" prefHeight="40.0" vgrow="SOMETIMES" />
-        <RowConstraints maxHeight="50.0" minHeight="0.0" prefHeight="50.0" vgrow="SOMETIMES" />
-        <RowConstraints maxHeight="40.0" minHeight="40.0" prefHeight="40.0" vgrow="SOMETIMES" />
-        <RowConstraints maxHeight="591.0" minHeight="10.0" prefHeight="130.0" vgrow="SOMETIMES" />
-        <RowConstraints maxHeight="591.0" minHeight="10.0" prefHeight="149.0" vgrow="SOMETIMES" />
-        <RowConstraints maxHeight="516.0" minHeight="10.0" prefHeight="152.0" vgrow="SOMETIMES" />
-        <RowConstraints maxHeight="263.0" minHeight="10.0" prefHeight="141.0" vgrow="SOMETIMES" />
+        <RowConstraints maxHeight="20.0" minHeight="0.0" prefHeight="20.0" vgrow="SOMETIMES" />
+        <RowConstraints maxHeight="61.0" minHeight="40.0" prefHeight="56.0" vgrow="SOMETIMES" />
+        <RowConstraints maxHeight="591.0" minHeight="10.0" prefHeight="53.0" vgrow="SOMETIMES" />
+        <RowConstraints maxHeight="591.0" minHeight="10.0" prefHeight="198.0" vgrow="SOMETIMES" />
+        <RowConstraints maxHeight="516.0" minHeight="10.0" prefHeight="197.0" vgrow="SOMETIMES" />
+        <RowConstraints maxHeight="263.0" minHeight="10.0" prefHeight="193.0" vgrow="SOMETIMES" />
     </rowConstraints>
     <children>
-        <StackedBarChart fx:id="expenditureBarChart" title="Expenditures per Month" GridPane.columnIndex="2" GridPane.columnSpan="4" GridPane.rowIndex="2" GridPane.rowSpan="5">
+        <StackedBarChart fx:id="expenditureBarChart" title="Expenditures per Month" GridPane.columnIndex="3" GridPane.columnSpan="4" GridPane.rowIndex="2" GridPane.rowSpan="5">
             <xAxis>
                 <CategoryAxis side="BOTTOM" />
             </xAxis>
@@ -53,10 +55,12 @@
                 </Text>
             </children>
         </Pane>
-      <GridPane GridPane.columnSpan="2" GridPane.rowIndex="2" GridPane.rowSpan="2">
+      <GridPane GridPane.columnSpan="3" GridPane.rowIndex="2" GridPane.rowSpan="2">
         <columnConstraints>
-            <ColumnConstraints hgrow="SOMETIMES" maxWidth="183.0" minWidth="10.0" prefWidth="113.0" />
-          <ColumnConstraints hgrow="SOMETIMES" maxWidth="265.0" minWidth="10.0" prefWidth="265.0" />
+            <ColumnConstraints hgrow="SOMETIMES" maxWidth="183.0" minWidth="10.0" prefWidth="138.0" />
+          <ColumnConstraints hgrow="SOMETIMES" maxWidth="305.0" minWidth="10.0" prefWidth="161.0" />
+            <ColumnConstraints hgrow="SOMETIMES" maxWidth="265.0" minWidth="10.0" prefWidth="43.0" />
+            <ColumnConstraints hgrow="SOMETIMES" maxWidth="265.0" minWidth="10.0" prefWidth="184.0" />
         </columnConstraints>
         <rowConstraints>
           <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
@@ -69,7 +73,7 @@
             <Insets left="20.0" />
          </GridPane.margin>
          <children>
-            <Text strokeType="OUTSIDE" strokeWidth="0.0" text="Account - " textAlignment="CENTER" wrappingWidth="148.107421875" GridPane.rowIndex="1">
+            <Text strokeType="OUTSIDE" strokeWidth="0.0" text="Account - " textAlignment="CENTER" wrappingWidth="80.107421875" GridPane.halignment="RIGHT" GridPane.rowIndex="1">
                <font>
                   <Font name="Calibri Light" size="18.0" />
                </font>
@@ -79,6 +83,18 @@
                   <Font name="Calibri Light" size="27.0" />
                </font></Text>
             <AccountDropdown fx:id="accountFilterDropdown" prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+            <Text strokeType="OUTSIDE" strokeWidth="0.0" text="Date - " textAlignment="CENTER" wrappingWidth="54.8564453125" GridPane.halignment="RIGHT" GridPane.rowIndex="2">
+               <font>
+                  <Font name="Calibri Light" size="18.0" />
+               </font>
+            </Text>
+            <DatePicker fx:id="fromDatefFilter" prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="2" />
+            <DatePicker fx:id="toDateFilter" prefWidth="150.0" GridPane.columnIndex="3" GridPane.rowIndex="2" />
+            <Text strokeType="OUTSIDE" strokeWidth="0.0" text="to" wrappingWidth="15.3017578125" GridPane.columnIndex="2" GridPane.halignment="CENTER" GridPane.rowIndex="2" GridPane.valignment="CENTER">
+               <font>
+                  <Font name="Calibri Light" size="18.0" />
+               </font>
+            </Text>
          </children>
       </GridPane>
     </children>

--- a/src/main/resources/fxml_files/ExpenditureCharts.fxml
+++ b/src/main/resources/fxml_files/ExpenditureCharts.fxml
@@ -5,7 +5,7 @@
 <?import javafx.scene.chart.CategoryAxis?>
 <?import javafx.scene.chart.LineChart?>
 <?import javafx.scene.chart.NumberAxis?>
-<?import javafx.scene.chart.StackedBarChart?>
+<?import javafx.scene.chart.PieChart?>
 <?import javafx.scene.control.Button?>
 <?import javafx.scene.control.DatePicker?>
 <?import javafx.scene.control.Label?>
@@ -38,17 +38,6 @@
         <RowConstraints maxHeight="263.0" minHeight="10.0" prefHeight="193.0" vgrow="SOMETIMES" />
     </rowConstraints>
     <children>
-        <StackedBarChart fx:id="expenditureBarChart" title="Filtered Expenditures" GridPane.columnIndex="3" GridPane.columnSpan="4" GridPane.rowIndex="2" GridPane.rowSpan="5">
-            <xAxis>
-                <CategoryAxis side="BOTTOM" />
-            </xAxis>
-            <yAxis>
-                <NumberAxis side="LEFT" />
-            </yAxis>
-            <GridPane.margin>
-                <Insets bottom="20.0" left="20.0" right="20.0" />
-            </GridPane.margin>
-        </StackedBarChart>
         <Pane fx:id="header" prefHeight="200.0" prefWidth="200.0" GridPane.columnSpan="7">
             <children>
                 <Text fx:id="title" fill="#ffa81f" layoutX="21.0" layoutY="31.0" strokeType="OUTSIDE" strokeWidth="0.0" text="TransACT">
@@ -123,6 +112,11 @@
             <Insets top="10.0" />
          </GridPane.margin>
       </LineChart>
+      <PieChart fx:id="expendituresPieChart" title="Filtered Expenditures" GridPane.columnIndex="3" GridPane.columnSpan="4" GridPane.rowIndex="2" GridPane.rowSpan="5">
+         <GridPane.margin>
+            <Insets bottom="20.0" left="20.0" right="20.0" top="20.0" />
+         </GridPane.margin>
+      </PieChart>
     </children>
     <stylesheets>
         <URL value="@../css/colorStyle.css" />

--- a/src/main/resources/fxml_files/ExpenditureCharts.fxml
+++ b/src/main/resources/fxml_files/ExpenditureCharts.fxml
@@ -35,7 +35,7 @@
         <RowConstraints maxHeight="263.0" minHeight="10.0" prefHeight="193.0" vgrow="SOMETIMES" />
     </rowConstraints>
     <children>
-        <StackedBarChart fx:id="expenditureBarChart" title="Expenditures per Month" GridPane.columnIndex="3" GridPane.columnSpan="4" GridPane.rowIndex="2" GridPane.rowSpan="5">
+        <StackedBarChart fx:id="expenditureBarChart" title="Expenditures" GridPane.columnIndex="3" GridPane.columnSpan="4" GridPane.rowIndex="2" GridPane.rowSpan="5">
             <xAxis>
                 <CategoryAxis side="BOTTOM" />
             </xAxis>

--- a/src/main/resources/fxml_files/ExpenditureCharts.fxml
+++ b/src/main/resources/fxml_files/ExpenditureCharts.fxml
@@ -3,6 +3,7 @@
 <?import java.net.URL?>
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.chart.CategoryAxis?>
+<?import javafx.scene.chart.LineChart?>
 <?import javafx.scene.chart.NumberAxis?>
 <?import javafx.scene.chart.StackedBarChart?>
 <?import javafx.scene.control.DatePicker?>
@@ -96,13 +97,24 @@
                   <Font name="Calibri Light" size="18.0" />
                </font>
             </Text>
-            <Label text="Currently showing: " GridPane.columnSpan="4" GridPane.halignment="CENTER" GridPane.rowIndex="4">
+            <Label text="Currently showing: " GridPane.columnSpan="4" GridPane.halignment="CENTER" GridPane.rowIndex="3">
                <font>
                   <Font name="Calibri Light" size="18.0" />
                </font>
             </Label>
          </children>
       </GridPane>
+      <LineChart fx:id="expendituresLineChart" prefHeight="156.0" prefWidth="135.0" title="Expenditures Over Time" GridPane.columnSpan="3" GridPane.rowIndex="4" GridPane.rowSpan="3">
+        <xAxis>
+          <CategoryAxis side="BOTTOM" />
+        </xAxis>
+        <yAxis>
+          <NumberAxis side="LEFT" />
+        </yAxis>
+         <padding>
+            <Insets bottom="25.0" />
+         </padding>
+      </LineChart>
     </children>
     <stylesheets>
         <URL value="@../css/colorStyle.css" />

--- a/src/main/resources/fxml_files/ExpenditureCharts.fxml
+++ b/src/main/resources/fxml_files/ExpenditureCharts.fxml
@@ -1,67 +1,59 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
+<?import java.net.URL?>
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.chart.CategoryAxis?>
 <?import javafx.scene.chart.NumberAxis?>
-<?import javafx.scene.chart.PieChart?>
 <?import javafx.scene.chart.StackedBarChart?>
-<?import javafx.scene.layout.*?>
+<?import javafx.scene.layout.ColumnConstraints?>
+<?import javafx.scene.layout.GridPane?>
+<?import javafx.scene.layout.Pane?>
+<?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.text.Font?>
 <?import javafx.scene.text.Text?>
-<?import java.net.URL?>
-<fx:root fx:id="mainBackground" maxHeight="800.0" maxWidth="1280.0" minHeight="800.0" minWidth="1280.0"
-         prefHeight="800.0" prefWidth="1280.0" style="-fx-background-color: #ffffff;" type="GridPane"
-         xmlns="http://javafx.com/javafx/8" xmlns:fx="http://javafx.com/fxml/1">
+
+<fx:root fx:id="mainBackground" maxHeight="800.0" maxWidth="1280.0" minHeight="800.0" minWidth="1280.0" prefHeight="800.0" prefWidth="1280.0" style="-fx-background-color: #ffffff;" type="GridPane" xmlns="http://javafx.com/javafx/8.0.101" xmlns:fx="http://javafx.com/fxml/1">
     <columnConstraints>
-        <ColumnConstraints hgrow="SOMETIMES" maxWidth="200.0" minWidth="200.0" prefWidth="200.0"/>
-        <ColumnConstraints hgrow="SOMETIMES" maxWidth="1048.0" minWidth="10.0" prefWidth="1034.0"/>
-        <ColumnConstraints hgrow="SOMETIMES" maxWidth="1048.0" minWidth="10.0" prefWidth="1034.0"/>
-        <ColumnConstraints hgrow="SOMETIMES" maxWidth="1048.0" minWidth="10.0" prefWidth="1034.0"/>
-        <ColumnConstraints hgrow="SOMETIMES" maxWidth="1048.0" minWidth="10.0" prefWidth="1034.0"/>
-        <ColumnConstraints hgrow="SOMETIMES" maxWidth="1048.0" minWidth="10.0" prefWidth="1034.0"/>
-        <ColumnConstraints hgrow="SOMETIMES" maxWidth="1048.0" minWidth="10.0" prefWidth="1034.0"/>
+        <ColumnConstraints hgrow="SOMETIMES" maxWidth="200.0" minWidth="200.0" prefWidth="200.0" />
+        <ColumnConstraints hgrow="SOMETIMES" maxWidth="1048.0" minWidth="10.0" prefWidth="1034.0" />
+        <ColumnConstraints hgrow="SOMETIMES" maxWidth="1048.0" minWidth="10.0" prefWidth="1034.0" />
+        <ColumnConstraints hgrow="SOMETIMES" maxWidth="1048.0" minWidth="10.0" prefWidth="1034.0" />
+        <ColumnConstraints hgrow="SOMETIMES" maxWidth="1048.0" minWidth="10.0" prefWidth="1034.0" />
+        <ColumnConstraints hgrow="SOMETIMES" maxWidth="1048.0" minWidth="10.0" prefWidth="1034.0" />
+        <ColumnConstraints hgrow="SOMETIMES" maxWidth="1048.0" minWidth="10.0" prefWidth="1034.0" />
     </columnConstraints>
     <rowConstraints>
-        <RowConstraints maxHeight="40.0" minHeight="40.0" prefHeight="40.0" vgrow="SOMETIMES"/>
-        <RowConstraints maxHeight="50.0" minHeight="0.0" prefHeight="50.0" vgrow="SOMETIMES"/>
-        <RowConstraints maxHeight="40.0" minHeight="40.0" prefHeight="40.0" vgrow="SOMETIMES"/>
-        <RowConstraints maxHeight="591.0" minHeight="10.0" prefHeight="130.0" vgrow="SOMETIMES"/>
-        <RowConstraints maxHeight="591.0" minHeight="10.0" prefHeight="149.0" vgrow="SOMETIMES"/>
-        <RowConstraints maxHeight="516.0" minHeight="10.0" prefHeight="152.0" vgrow="SOMETIMES"/>
-        <RowConstraints maxHeight="263.0" minHeight="10.0" prefHeight="141.0" vgrow="SOMETIMES"/>
+        <RowConstraints maxHeight="40.0" minHeight="40.0" prefHeight="40.0" vgrow="SOMETIMES" />
+        <RowConstraints maxHeight="50.0" minHeight="0.0" prefHeight="50.0" vgrow="SOMETIMES" />
+        <RowConstraints maxHeight="40.0" minHeight="40.0" prefHeight="40.0" vgrow="SOMETIMES" />
+        <RowConstraints maxHeight="591.0" minHeight="10.0" prefHeight="130.0" vgrow="SOMETIMES" />
+        <RowConstraints maxHeight="591.0" minHeight="10.0" prefHeight="149.0" vgrow="SOMETIMES" />
+        <RowConstraints maxHeight="516.0" minHeight="10.0" prefHeight="152.0" vgrow="SOMETIMES" />
+        <RowConstraints maxHeight="263.0" minHeight="10.0" prefHeight="141.0" vgrow="SOMETIMES" />
     </rowConstraints>
     <children>
-        <PieChart fx:id="expenditurePieChart" prefHeight="277.0" prefWidth="271.0"
-                  title="Expenditure Categories (last 6 mos.)" GridPane.columnSpan="3" GridPane.rowIndex="2"
-                  GridPane.rowSpan="5">
-            <GridPane.margin>
-                <Insets bottom="20.0" left="20.0"/>
-            </GridPane.margin>
-        </PieChart>
-        <StackedBarChart fx:id="expenditureBarChart" title="Expenditures per Month" GridPane.columnIndex="3"
-                         GridPane.columnSpan="4" GridPane.rowIndex="2" GridPane.rowSpan="5">
+        <StackedBarChart fx:id="expenditureBarChart" title="Expenditures per Month" GridPane.columnIndex="3" GridPane.columnSpan="4" GridPane.rowIndex="2" GridPane.rowSpan="5">
             <xAxis>
-                <CategoryAxis side="BOTTOM"/>
+                <CategoryAxis side="BOTTOM" />
             </xAxis>
             <yAxis>
-                <NumberAxis side="LEFT"/>
+                <NumberAxis side="LEFT" />
             </yAxis>
             <GridPane.margin>
-                <Insets bottom="20.0" left="20.0" right="20.0"/>
+                <Insets bottom="20.0" left="20.0" right="20.0" />
             </GridPane.margin>
         </StackedBarChart>
         <Pane fx:id="header" prefHeight="200.0" prefWidth="200.0" GridPane.columnSpan="7">
             <children>
-                <Text fx:id="title" fill="#ffa81f" layoutX="21.0" layoutY="31.0" strokeType="OUTSIDE" strokeWidth="0.0"
-                      text="TransACT">
+                <Text fx:id="title" fill="#ffa81f" layoutX="21.0" layoutY="31.0" strokeType="OUTSIDE" strokeWidth="0.0" text="TransACT">
                     <font>
-                        <Font name="Calibri Bold" size="34.0"/>
+                        <Font name="Calibri Bold" size="34.0" />
                     </font>
                 </Text>
             </children>
         </Pane>
     </children>
     <stylesheets>
-        <URL value="@../css/colorStyle.css"/>
+        <URL value="@../css/colorStyle.css" />
     </stylesheets>
 </fx:root>

--- a/src/main/resources/fxml_files/ExpenditureCharts.fxml
+++ b/src/main/resources/fxml_files/ExpenditureCharts.fxml
@@ -6,6 +6,7 @@
 <?import javafx.scene.chart.LineChart?>
 <?import javafx.scene.chart.NumberAxis?>
 <?import javafx.scene.chart.StackedBarChart?>
+<?import javafx.scene.control.Button?>
 <?import javafx.scene.control.DatePicker?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.layout.ColumnConstraints?>
@@ -102,6 +103,7 @@
                   <Font name="Calibri Light" size="18.0" />
                </font>
             </Label>
+            <Button fx:id="filterEnterButton" mnemonicParsing="false" prefHeight="33.0" prefWidth="84.0" text="Enter" textAlignment="CENTER" GridPane.columnIndex="3" GridPane.halignment="CENTER" GridPane.rowIndex="4" />
          </children>
       </GridPane>
       <LineChart fx:id="expendituresLineChart" prefHeight="156.0" prefWidth="135.0" title="Expenditures Over Time" GridPane.columnSpan="3" GridPane.rowIndex="4" GridPane.rowSpan="3">

--- a/src/main/resources/fxml_files/ExpenditureCharts.fxml
+++ b/src/main/resources/fxml_files/ExpenditureCharts.fxml
@@ -118,7 +118,7 @@
             <Insets top="10.0" />
          </GridPane.margin>
       </LineChart>
-      <PieChart fx:id="expendituresPieChart" GridPane.columnIndex="3" GridPane.columnSpan="4" GridPane.rowIndex="2" GridPane.rowSpan="5">
+      <PieChart fx:id="expendituresPieChart" animated="false" GridPane.columnIndex="3" GridPane.columnSpan="4" GridPane.rowIndex="2" GridPane.rowSpan="5">
          <GridPane.margin>
             <Insets bottom="20.0" left="20.0" right="20.0" top="20.0" />
          </GridPane.margin>

--- a/src/main/resources/fxml_files/ExpenditureCharts.fxml
+++ b/src/main/resources/fxml_files/ExpenditureCharts.fxml
@@ -6,6 +6,7 @@
 <?import javafx.scene.chart.NumberAxis?>
 <?import javafx.scene.chart.StackedBarChart?>
 <?import javafx.scene.control.DatePicker?>
+<?import javafx.scene.control.Label?>
 <?import javafx.scene.layout.ColumnConstraints?>
 <?import javafx.scene.layout.GridPane?>
 <?import javafx.scene.layout.Pane?>
@@ -95,6 +96,11 @@
                   <Font name="Calibri Light" size="18.0" />
                </font>
             </Text>
+            <Label text="Currently showing: " GridPane.columnSpan="4" GridPane.halignment="CENTER" GridPane.rowIndex="4">
+               <font>
+                  <Font name="Calibri Light" size="18.0" />
+               </font>
+            </Label>
          </children>
       </GridPane>
     </children>

--- a/src/main/resources/fxml_files/ExpenditureCharts.fxml
+++ b/src/main/resources/fxml_files/ExpenditureCharts.fxml
@@ -11,16 +11,17 @@
 <?import javafx.scene.layout.RowConstraints?>
 <?import javafx.scene.text.Font?>
 <?import javafx.scene.text.Text?>
+<?import ledger.user_interface.ui_controllers.AccountDropdown?>
 
 <fx:root fx:id="mainBackground" maxHeight="800.0" maxWidth="1280.0" minHeight="800.0" minWidth="1280.0" prefHeight="800.0" prefWidth="1280.0" style="-fx-background-color: #ffffff;" type="GridPane" xmlns="http://javafx.com/javafx/8.0.101" xmlns:fx="http://javafx.com/fxml/1">
     <columnConstraints>
-        <ColumnConstraints hgrow="SOMETIMES" maxWidth="200.0" minWidth="200.0" prefWidth="200.0" />
+        <ColumnConstraints hgrow="SOMETIMES" maxWidth="200.0" minWidth="178.0" prefWidth="178.0" />
         <ColumnConstraints hgrow="SOMETIMES" maxWidth="1048.0" minWidth="10.0" prefWidth="1034.0" />
         <ColumnConstraints hgrow="SOMETIMES" maxWidth="1048.0" minWidth="10.0" prefWidth="1034.0" />
         <ColumnConstraints hgrow="SOMETIMES" maxWidth="1048.0" minWidth="10.0" prefWidth="1034.0" />
         <ColumnConstraints hgrow="SOMETIMES" maxWidth="1048.0" minWidth="10.0" prefWidth="1034.0" />
         <ColumnConstraints hgrow="SOMETIMES" maxWidth="1048.0" minWidth="10.0" prefWidth="1034.0" />
-        <ColumnConstraints hgrow="SOMETIMES" maxWidth="1048.0" minWidth="10.0" prefWidth="1034.0" />
+      <ColumnConstraints />
     </columnConstraints>
     <rowConstraints>
         <RowConstraints maxHeight="40.0" minHeight="40.0" prefHeight="40.0" vgrow="SOMETIMES" />
@@ -32,7 +33,7 @@
         <RowConstraints maxHeight="263.0" minHeight="10.0" prefHeight="141.0" vgrow="SOMETIMES" />
     </rowConstraints>
     <children>
-        <StackedBarChart fx:id="expenditureBarChart" title="Expenditures per Month" GridPane.columnIndex="3" GridPane.columnSpan="4" GridPane.rowIndex="2" GridPane.rowSpan="5">
+        <StackedBarChart fx:id="expenditureBarChart" title="Expenditures per Month" GridPane.columnIndex="2" GridPane.columnSpan="4" GridPane.rowIndex="2" GridPane.rowSpan="5">
             <xAxis>
                 <CategoryAxis side="BOTTOM" />
             </xAxis>
@@ -52,6 +53,34 @@
                 </Text>
             </children>
         </Pane>
+      <GridPane GridPane.columnSpan="2" GridPane.rowIndex="2" GridPane.rowSpan="2">
+        <columnConstraints>
+            <ColumnConstraints hgrow="SOMETIMES" maxWidth="183.0" minWidth="10.0" prefWidth="113.0" />
+          <ColumnConstraints hgrow="SOMETIMES" maxWidth="265.0" minWidth="10.0" prefWidth="265.0" />
+        </columnConstraints>
+        <rowConstraints>
+          <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+            <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+          <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+          <RowConstraints minHeight="10.0" prefHeight="30.0" vgrow="SOMETIMES" />
+        </rowConstraints>
+         <GridPane.margin>
+            <Insets left="20.0" />
+         </GridPane.margin>
+         <children>
+            <Text strokeType="OUTSIDE" strokeWidth="0.0" text="Account - " textAlignment="CENTER" wrappingWidth="148.107421875" GridPane.rowIndex="1">
+               <font>
+                  <Font name="Calibri Light" size="18.0" />
+               </font>
+            </Text>
+            <Text strokeType="OUTSIDE" strokeWidth="0.0" text="Filter By:" GridPane.halignment="CENTER" GridPane.valignment="CENTER">
+               <font>
+                  <Font name="Calibri Light" size="27.0" />
+               </font></Text>
+            <AccountDropdown fx:id="accountFilterDropdown" prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="1" />
+         </children>
+      </GridPane>
     </children>
     <stylesheets>
         <URL value="@../css/colorStyle.css" />

--- a/src/main/resources/fxml_files/ExpenditureCharts.fxml
+++ b/src/main/resources/fxml_files/ExpenditureCharts.fxml
@@ -58,7 +58,7 @@
                 </Text>
             </children>
         </Pane>
-      <GridPane GridPane.columnSpan="3" GridPane.rowIndex="2" GridPane.rowSpan="2">
+      <GridPane style="-fx-border-color: #5667B5; -fx-border-radius: 10; -fx-border-width: 2;" GridPane.columnSpan="3" GridPane.rowIndex="2" GridPane.rowSpan="2">
         <columnConstraints>
             <ColumnConstraints hgrow="SOMETIMES" maxWidth="183.0" minWidth="10.0" prefWidth="138.0" />
           <ColumnConstraints hgrow="SOMETIMES" maxWidth="305.0" minWidth="10.0" prefWidth="161.0" />
@@ -105,6 +105,9 @@
             </Label>
             <Button fx:id="filterEnterButton" mnemonicParsing="false" prefHeight="33.0" prefWidth="84.0" text="Enter" textAlignment="CENTER" GridPane.columnIndex="3" GridPane.halignment="CENTER" GridPane.rowIndex="4" />
          </children>
+         <padding>
+            <Insets bottom="5.0" />
+         </padding>
       </GridPane>
       <LineChart fx:id="expendituresLineChart" prefHeight="156.0" prefWidth="135.0" title="Expenditures Over Time" GridPane.columnSpan="3" GridPane.rowIndex="4" GridPane.rowSpan="3">
         <xAxis>
@@ -116,6 +119,9 @@
          <padding>
             <Insets bottom="25.0" />
          </padding>
+         <GridPane.margin>
+            <Insets top="10.0" />
+         </GridPane.margin>
       </LineChart>
     </children>
     <stylesheets>

--- a/src/main/resources/fxml_files/ExpenditureCharts.fxml
+++ b/src/main/resources/fxml_files/ExpenditureCharts.fxml
@@ -38,7 +38,7 @@
         <RowConstraints maxHeight="263.0" minHeight="10.0" prefHeight="193.0" vgrow="SOMETIMES" />
     </rowConstraints>
     <children>
-        <StackedBarChart fx:id="expenditureBarChart" title="Expenditures" GridPane.columnIndex="3" GridPane.columnSpan="4" GridPane.rowIndex="2" GridPane.rowSpan="5">
+        <StackedBarChart fx:id="expenditureBarChart" title="Filtered Expenditures" GridPane.columnIndex="3" GridPane.columnSpan="4" GridPane.rowIndex="2" GridPane.rowSpan="5">
             <xAxis>
                 <CategoryAxis side="BOTTOM" />
             </xAxis>
@@ -91,7 +91,7 @@
                   <Font name="Calibri Light" size="18.0" />
                </font>
             </Text>
-            <DatePicker fx:id="fromDatefFilter" prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="2" />
+            <DatePicker fx:id="fromDateFilter" prefWidth="150.0" GridPane.columnIndex="1" GridPane.rowIndex="2" />
             <DatePicker fx:id="toDateFilter" prefWidth="150.0" GridPane.columnIndex="3" GridPane.rowIndex="2" />
             <Text strokeType="OUTSIDE" strokeWidth="0.0" text="to" wrappingWidth="15.3017578125" GridPane.columnIndex="2" GridPane.halignment="CENTER" GridPane.rowIndex="2" GridPane.valignment="CENTER">
                <font>
@@ -109,7 +109,7 @@
             <Insets bottom="5.0" />
          </padding>
       </GridPane>
-      <LineChart fx:id="expendituresLineChart" prefHeight="156.0" prefWidth="135.0" title="Expenditures Over Time" GridPane.columnSpan="3" GridPane.rowIndex="4" GridPane.rowSpan="3">
+      <LineChart fx:id="expendituresLineChart" prefHeight="156.0" prefWidth="135.0" title="Expenditure History" GridPane.columnSpan="3" GridPane.rowIndex="4" GridPane.rowSpan="3">
         <xAxis>
           <CategoryAxis side="BOTTOM" />
         </xAxis>


### PR DESCRIPTION
Expenditures page now has two functional charts. The LineChart on the left hand side shows the change in overall balance (how much they spent/deposited) each month for the last six months. This is a general overview of everything and is therefore not restricted by account. The PieChart on the right hand side is more dynamic. It will show proportions of how much was spent in each category (determined by tags, basically). It can be filtered by account and/or by date range. This chart doesn't look at deposits, only expenditures. I figured this was best in the case that the end user would want to see what they are spending most of their money on.

If you have any questions, or if something doesn't make sense, shoot me a slack message!