### PR TITLE
[LED-119] Implemented file extension filters

### DIFF
--- a/src/main/java/ledger/user_interface/ui_controllers/FileSelectorButton.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/FileSelectorButton.java
@@ -3,8 +3,11 @@ package ledger.user_interface.ui_controllers;
 import javafx.event.ActionEvent;
 import javafx.scene.control.Button;
 import javafx.stage.FileChooser;
+import javafx.stage.FileChooser.ExtensionFilter;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Created by CJ on 10/24/2016.
@@ -12,17 +15,19 @@ import java.io.File;
 public class FileSelectorButton extends Button {
 
     private File file;
+    private List<ExtensionFilter> fileExtentionFilters;
 
     public FileSelectorButton() {
         super();
         this.setText("Select File");
+        this.fileExtentionFilters = new ArrayList<>();
 
         this.setOnAction(this::OnAction);
-
     }
 
     private void OnAction(ActionEvent actionEvent) {
         FileChooser chooser = new FileChooser();
+        chooser.getExtensionFilters().addAll(this.fileExtentionFilters);
         File selectedFile = chooser.showOpenDialog(this.getScene().getWindow());
         if (selectedFile != null) {
             this.file = selectedFile;
@@ -32,5 +37,17 @@ public class FileSelectorButton extends Button {
 
     public File getFile() {
         return file;
+    }
+
+    public void addFileExtensionFilter(ExtensionFilter e) {
+        this.fileExtentionFilters.add(e);
+    }
+
+    public void removeFileExtensionFilter(ExtensionFilter e) {
+        this.fileExtentionFilters.remove(e);
+    }
+
+    public void clearFileExtensionFilter() {
+        this.fileExtentionFilters.clear();
     }
 }

--- a/src/main/java/ledger/user_interface/ui_controllers/ImportTransactionsPopupController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/ImportTransactionsPopupController.java
@@ -6,6 +6,7 @@ import javafx.fxml.Initializable;
 import javafx.scene.Scene;
 import javafx.scene.control.Button;
 import javafx.scene.layout.GridPane;
+import javafx.stage.FileChooser.ExtensionFilter;
 import javafx.stage.Modality;
 import javafx.stage.Stage;
 import ledger.controller.ImportController;
@@ -53,6 +54,9 @@ public class ImportTransactionsPopupController extends GridPane implements Initi
      */
     @Override
     public void initialize(URL fxmlFileLocation, ResourceBundle resources) {
+        fileSelector.addFileExtensionFilter(new ExtensionFilter("CSV files (*.csv)", "*.csv"));
+        fileSelector.addFileExtensionFilter(new ExtensionFilter("QFX files (*.qfx)", "*.qfx"));
+        fileSelector.addFileExtensionFilter(new ExtensionFilter("All files (*.*)", "*.*"));
         importButton.setOnAction(this::importFile);
         // TODO Hook up insert
     }

--- a/src/main/java/ledger/user_interface/ui_controllers/ImportTransactionsPopupController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/ImportTransactionsPopupController.java
@@ -54,9 +54,9 @@ public class ImportTransactionsPopupController extends GridPane implements Initi
      */
     @Override
     public void initialize(URL fxmlFileLocation, ResourceBundle resources) {
+        fileSelector.addFileExtensionFilter(new ExtensionFilter("All files (*.*)", "*.*"));
         fileSelector.addFileExtensionFilter(new ExtensionFilter("CSV files (*.csv)", "*.csv"));
         fileSelector.addFileExtensionFilter(new ExtensionFilter("QFX files (*.qfx)", "*.qfx"));
-        fileSelector.addFileExtensionFilter(new ExtensionFilter("All files (*.*)", "*.*"));
         importButton.setOnAction(this::importFile);
         // TODO Hook up insert
     }


### PR DESCRIPTION
I added the ability to set file extension filters for our custom FileSelectorButton UI controller. I've only set up filters for the Import Transactions popup, but this new feature can be used anywhere we use our FileSelectorButton. I added filters for .csv, .qfx, and all files (all case insensitive), as per Sean's request.