### PR TITLE
[LED-141] Multiple selection in the transaction table view

### DIFF
--- a/src/main/java/ledger/user_interface/ui_controllers/TransactionTableView.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/TransactionTableView.java
@@ -7,6 +7,7 @@ import javafx.collections.transformation.SortedList;
 import javafx.event.EventHandler;
 import javafx.fxml.FXML;
 import javafx.fxml.Initializable;
+import javafx.scene.control.SelectionMode;
 import javafx.scene.control.TableColumn;
 import javafx.scene.control.TableColumn.CellEditEvent;
 import javafx.scene.control.TableView;
@@ -274,6 +275,8 @@ public class TransactionTableView extends TableView<TransactionModel> implements
                 }
             }
         });
+
+        this.getSelectionModel().setSelectionMode(SelectionMode.MULTIPLE);
     }
 
     public void updateTransactionTableView() {
@@ -343,17 +346,20 @@ public class TransactionTableView extends TableView<TransactionModel> implements
     private void handleDeleteTransactionFromTableView() {
         int selectedIndex = this.getSelectionModel().getSelectedIndex();
         if (selectedIndex >= 0) {
-            TransactionModel model = (TransactionModel) this.getItems().get(selectedIndex);
-            Transaction transactionToDelete = model.getTransaction();
+            ObservableList<TransactionModel> transactionModelsToDelete = this.getSelectionModel().getSelectedItems();
 
-            TaskWithArgs<Transaction> task = DbController.INSTANCE.deleteTransaction(transactionToDelete);
-            task.RegisterFailureEvent((e) -> {
-                updateTransactionTableView();
-                setupErrorPopup("Error deleting transaction.", e);
-            });
+            for (TransactionModel currentModel : transactionModelsToDelete) {
+                Transaction transactionToDelete = currentModel.getTransaction();
+
+                TaskWithArgs<Transaction> task = DbController.INSTANCE.deleteTransaction(transactionToDelete);
+                task.RegisterFailureEvent((e) -> {
+                    updateTransactionTableView();
+                    setupErrorPopup("Error deleting transaction.", e);
+                });
 //                task.RegisterSuccessEvent(() -> updateTransactionTableView());
-            task.startTask();
-            task.waitForComplete();
+                task.startTask();
+                task.waitForComplete();
+            }
             updateTransactionTableView();
         } else {
             setupErrorPopup("No transactions deleted.", new NullPointerException("No transaction deleted."));

--- a/src/main/java/ledger/user_interface/ui_controllers/TransactionTableView.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/TransactionTableView.java
@@ -25,10 +25,7 @@ import ledger.user_interface.utils.*;
 
 import java.net.URL;
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.ResourceBundle;
+import java.util.*;
 
 /**
  * Controls all input and interaction with the Main Page of the application
@@ -346,9 +343,24 @@ public class TransactionTableView extends TableView<TransactionModel> implements
     private void handleDeleteTransactionFromTableView() {
         int selectedIndex = this.getSelectionModel().getSelectedIndex();
         if (selectedIndex >= 0) {
-            ObservableList<TransactionModel> transactionModelsToDelete = this.getSelectionModel().getSelectedItems();
+//            ObservableList<TransactionModel> transactionModelsToDelete = this.getSelectionModel().getSelectedItems();
 
-            for (TransactionModel currentModel : transactionModelsToDelete) {
+            List<Integer> indices = this.getSelectionModel().getSelectedIndices();
+            while(indices.contains(new Integer(-1))) {
+                System.out.println("fix");
+                indices = this.getSelectionModel().getSelectedIndices();
+            }
+            System.out.println(indices.toString());
+
+            ArrayList<TransactionModel> models = new ArrayList<>();
+            for (int i : indices) {
+                models.add(this.getItems().get(i));
+            }
+            for (TransactionModel currentModel : models) {
+                if (currentModel == null) {
+                    System.err.println("Oh shit its null ");
+                    continue;
+                }
                 Transaction transactionToDelete = currentModel.getTransaction();
 
                 TaskWithArgs<Transaction> task = DbController.INSTANCE.deleteTransaction(transactionToDelete);
@@ -356,7 +368,6 @@ public class TransactionTableView extends TableView<TransactionModel> implements
                     updateTransactionTableView();
                     setupErrorPopup("Error deleting transaction.", e);
                 });
-//                task.RegisterSuccessEvent(() -> updateTransactionTableView());
                 task.startTask();
                 task.waitForComplete();
             }

--- a/src/main/java/ledger/user_interface/ui_controllers/TransactionTableView.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/TransactionTableView.java
@@ -347,7 +347,6 @@ public class TransactionTableView extends TableView<TransactionModel> implements
         if (indices.size() != 0) {
 
             if(indices.contains(new Integer(-1))) {
-                System.out.println("fix");
                 indices = this.getSelectionModel().getSelectedIndices();
             }
 

--- a/src/main/java/ledger/user_interface/ui_controllers/TransactionTableView.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/TransactionTableView.java
@@ -341,26 +341,18 @@ public class TransactionTableView extends TableView<TransactionModel> implements
     }
 
     private void handleDeleteTransactionFromTableView() {
-        ObservableList<Integer> indices = this.getSelectionModel().getSelectedIndices();
+        List<Integer> indices = new ArrayList<>();
         // Add indices to new list so they aren't observable
-        //indices.addAll(this.getSelectionModel().getSelectedIndices());
+        indices.addAll(this.getSelectionModel().getSelectedIndices());
         if (indices.size() != 0) {
 
-            while(indices.contains(new Integer(-1))) {
+            if(indices.contains(new Integer(-1))) {
                 System.out.println("fix");
                 indices = this.getSelectionModel().getSelectedIndices();
             }
 
-            ArrayList<TransactionModel> models = new ArrayList<>();
             for (int i : indices) {
-                models.add(this.getItems().get(i));
-            }
-            for (TransactionModel currentModel : models) {
-                if (currentModel == null) {
-                    System.err.println("Oh shit its null ");
-                    continue;
-                }
-                Transaction transactionToDelete = currentModel.getTransaction();
+                Transaction transactionToDelete = this.getItems().get(i).getTransaction();
 
                 TaskWithArgs<Transaction> task = DbController.INSTANCE.deleteTransaction(transactionToDelete);
                 task.RegisterFailureEvent((e) -> {
@@ -371,8 +363,6 @@ public class TransactionTableView extends TableView<TransactionModel> implements
                 task.waitForComplete();
             }
             updateTransactionTableView();
-        } else {
-            setupErrorPopup("No transactions deleted.", new NullPointerException("No transaction deleted."));
         }
     }
 

--- a/src/main/java/ledger/user_interface/ui_controllers/TransactionTableView.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/TransactionTableView.java
@@ -346,6 +346,7 @@ public class TransactionTableView extends TableView<TransactionModel> implements
         indices.addAll(this.getSelectionModel().getSelectedIndices());
         if (indices.size() != 0) {
 
+            //TODO: Get around this scary mess
             if(indices.contains(new Integer(-1))) {
                 indices = this.getSelectionModel().getSelectedIndices();
             }

--- a/src/main/java/ledger/user_interface/ui_controllers/TransactionTableView.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/TransactionTableView.java
@@ -1,6 +1,7 @@
 package ledger.user_interface.ui_controllers;
 
 import javafx.collections.FXCollections;
+import javafx.collections.ListChangeListener;
 import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import javafx.collections.transformation.SortedList;
@@ -77,7 +78,7 @@ public class TransactionTableView extends TableView<TransactionModel> implements
 
             TaskWithArgs<Transaction> task = DbController.INSTANCE.editTransaction(transaction);
             task.RegisterFailureEvent((e) -> {
-                updateTransactionTableView();
+                asyncTableUpdate();
                 setupErrorPopup("Error editing transaction amount.", e);
             });
 //                task.RegisterSuccessEvent(() -> updateTransactionTableView());
@@ -100,7 +101,7 @@ public class TransactionTableView extends TableView<TransactionModel> implements
 
             TaskWithArgs<Transaction> task = DbController.INSTANCE.editTransaction(transaction);
             task.RegisterFailureEvent((e) -> {
-                updateTransactionTableView();
+                asyncTableUpdate();
                 setupErrorPopup("Error editing transaction date.", e);
             });
 
@@ -121,7 +122,7 @@ public class TransactionTableView extends TableView<TransactionModel> implements
 
             TaskWithArgs<Transaction> task = DbController.INSTANCE.editTransaction(transaction);
             task.RegisterFailureEvent((e) -> {
-                updateTransactionTableView();
+                asyncTableUpdate();
                 setupErrorPopup("Error editing transaction payee.", e);
             });
 
@@ -142,7 +143,7 @@ public class TransactionTableView extends TableView<TransactionModel> implements
 
             TaskWithArgs<Transaction> task = DbController.INSTANCE.editTransaction(transaction);
             task.RegisterFailureEvent((e) -> {
-                updateTransactionTableView();
+                asyncTableUpdate();
                 setupErrorPopup("Error editing transaction type.", e);
             });
 
@@ -182,7 +183,7 @@ public class TransactionTableView extends TableView<TransactionModel> implements
 
             TaskWithArgs<Transaction> task = DbController.INSTANCE.editTransaction(transaction);
             task.RegisterFailureEvent((e) -> {
-                updateTransactionTableView();
+                asyncTableUpdate();
                 setupErrorPopup("Error editing transaction categories.", e);
             });
 
@@ -203,7 +204,7 @@ public class TransactionTableView extends TableView<TransactionModel> implements
 
             TaskWithArgs<Transaction> task = DbController.INSTANCE.editTransaction(transaction);
             task.RegisterFailureEvent((e) -> {
-                updateTransactionTableView();
+                asyncTableUpdate();
                 setupErrorPopup("Error editing transaction pending field.", e);
             });
 
@@ -268,7 +269,6 @@ public class TransactionTableView extends TableView<TransactionModel> implements
                 //Put your awesome application specific logic here
                 if (t.getCode() == KeyCode.DELETE) {
                     handleDeleteTransactionFromTableView();
-                    updateTransactionTableView();
                 }
             }
         });
@@ -341,16 +341,15 @@ public class TransactionTableView extends TableView<TransactionModel> implements
     }
 
     private void handleDeleteTransactionFromTableView() {
-        int selectedIndex = this.getSelectionModel().getSelectedIndex();
-        if (selectedIndex >= 0) {
-//            ObservableList<TransactionModel> transactionModelsToDelete = this.getSelectionModel().getSelectedItems();
+        ObservableList<Integer> indices = this.getSelectionModel().getSelectedIndices();
+        // Add indices to new list so they aren't observable
+        //indices.addAll(this.getSelectionModel().getSelectedIndices());
+        if (indices.size() != 0) {
 
-            List<Integer> indices = this.getSelectionModel().getSelectedIndices();
             while(indices.contains(new Integer(-1))) {
                 System.out.println("fix");
                 indices = this.getSelectionModel().getSelectedIndices();
             }
-            System.out.println(indices.toString());
 
             ArrayList<TransactionModel> models = new ArrayList<>();
             for (int i : indices) {
@@ -365,7 +364,7 @@ public class TransactionTableView extends TableView<TransactionModel> implements
 
                 TaskWithArgs<Transaction> task = DbController.INSTANCE.deleteTransaction(transactionToDelete);
                 task.RegisterFailureEvent((e) -> {
-                    updateTransactionTableView();
+                    asyncTableUpdate();
                     setupErrorPopup("Error deleting transaction.", e);
                 });
                 task.startTask();


### PR DESCRIPTION
I've been working on implementing this feature, but has run into a bug in my code. The only operation I'm concerned about with multiple selection is deleting transactions. Deleting a single selected transaction works, as does deleting multiple transactions which were selected by CTRL-clicking. The problem only occurs when SHIFT-clicking to select a range. When a SHIFT-click range is deleted, a null pointer exception will occasionally be throw when retrieving the Transaction from the TransactionModel. Unfortunately, I haven't been able to identify the cause, and it's quite difficult to replicate (it seems to occur randomly, ~10% of the time). I'd like to get some of you guys to test it and see if you can find something I might've missed. Thanks!