### PR TITLE
Fixed Expenditure Charts error on master

### DIFF
--- a/src/main/java/ledger/user_interface/ui_controllers/window/ExpenditureChartsController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/window/ExpenditureChartsController.java
@@ -39,8 +39,6 @@ public class ExpenditureChartsController extends GridPane implements Initializab
     @FXML
     private PieChart expendituresPieChart;
     @FXML
-    private Label currentlyShowingLabel;
-    @FXML
     private LineChart expendituresLineChart;
     @FXML
     private Button filterEnterButton;
@@ -78,7 +76,6 @@ public class ExpenditureChartsController extends GridPane implements Initializab
                 return;
             }
             if ((accountSelected != null) && ((fromDateSelected == null) || (toDateSelected == null))) {
-                this.currentlyShowingLabel.setText("Currently showing expenditures for account: " + accountSelected.getName());
                 createBasedOnAccount(accountSelected);
             }
             if ((accountSelected == null) && (fromDateSelected != null) && (toDateSelected != null)) {
@@ -86,7 +83,6 @@ public class ExpenditureChartsController extends GridPane implements Initializab
                     this.setupErrorPopup("Ensure your dates are in chronological order!", new Exception());
                     return;
                 }
-                this.currentlyShowingLabel.setText("Currently showing expenditures for the above date range.");
                 createBasedOnDateRange(fromDateSelected, toDateSelected);
             }
             if ((accountSelected != null) && (fromDateSelected != null) && (toDateSelected != null)) {
@@ -94,7 +90,6 @@ public class ExpenditureChartsController extends GridPane implements Initializab
                     this.setupErrorPopup("Ensure your dates are in chronological order!", new Exception());
                     return;
                 }
-                this.currentlyShowingLabel.setText("Currently showing expenditures for account: " + accountSelected.getName() + " within the above date range.");
                 createBasedOnAccountAndDateRange(accountSelected, fromDateSelected, toDateSelected);
             }
         });


### PR DESCRIPTION
I found an error that had somehow made it into master. There was a label that was removed when the Expenditures UI was refactored a while ago, and for some reason the code still referenced it and would break when you clicked the enter button. I just removed it.