### PR TITLE
Fix account dropdown

### DIFF
--- a/src/main/java/ledger/user_interface/ui_controllers/component/FilteringAccountDropdown.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/component/FilteringAccountDropdown.java
@@ -38,7 +38,11 @@ public class FilteringAccountDropdown extends AccountDropdown {
         accounts.add(allAccounts);
 
         this.setItems(FXCollections.observableArrayList(accounts));
-        this.setValue(currentSelection);
+        if(this.getItems().contains(currentSelection))
+            this.setValue(currentSelection);
+        else {
+            this.setValue(allAccounts);
+        }
     }
 
     /**

--- a/src/main/java/ledger/user_interface/ui_controllers/window/MainPageController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/window/MainPageController.java
@@ -203,7 +203,6 @@ public class MainPageController extends GridPane implements Initializable, IUICo
         if (result.get() == ButtonType.OK) {
             // ... user chose OK
             TaskWithArgs<Account> t = DbController.INSTANCE.deleteAccount(chooseAccount.getSelectedAccount());
-            t.RegisterSuccessEvent(() -> Startup.INSTANCE.runLater(() -> chooseAccount.selectDefault()));
             t.RegisterFailureEvent((e) -> {
                 e.printStackTrace();
             });


### PR DESCRIPTION
The account dropdown in the top left would not update correctly when an account was deleted by an action other then the Main Page's Delete account.

This bug was found in #162 