### PR TITLE
Stack-trace on Update Check with no Internet

### DIFF
--- a/src/main/java/ledger/updater/GitHubChecker.java
+++ b/src/main/java/ledger/updater/GitHubChecker.java
@@ -81,7 +81,7 @@ public class GitHubChecker {
                 return true;
             }
         } catch (IOException e) {
-            e.printStackTrace();
+            System.err.println("Unable to retch Github to check for updates.");
         }
         return false;
     }

--- a/src/main/java/ledger/updater/GitHubChecker.java
+++ b/src/main/java/ledger/updater/GitHubChecker.java
@@ -81,7 +81,7 @@ public class GitHubChecker {
                 return true;
             }
         } catch (IOException e) {
-            System.err.println("Unable to retch Github to check for updates.");
+            System.err.println("Unable to reach Github to check for updates.");
         }
         return false;
     }


### PR DESCRIPTION
Changing the printing of the stack-trace to print out a descriptive error message.

Test by turning off your internet and running.