### PR TITLE
[LED-175] Fix Modal Issue #217

### DIFF
--- a/src/main/java/ledger/user_interface/ui_controllers/IUIController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/IUIController.java
@@ -1,5 +1,6 @@
 package ledger.user_interface.ui_controllers;
 
+import com.sun.org.apache.xpath.internal.operations.Mod;
 import javafx.fxml.FXMLLoader;
 import javafx.geometry.Insets;
 import javafx.scene.Group;
@@ -121,17 +122,21 @@ public interface IUIController {
     }
 
     default void createModal(Window parent, Scene child, String windowName, boolean resizeable) {
-        createModal(parent, child, windowName, resizeable, StageStyle.UTILITY);
+        createModal(parent, child, windowName, resizeable, Modality.APPLICATION_MODAL);
     }
 
-    default void createModal(Window parent, Scene child, String windowName, boolean resizeable, StageStyle stageStyle) {
+    default void createModal(Window parent, Scene child, String windowName, boolean resizeable, Modality modality) {
+        createModal(parent, child, windowName, resizeable, modality, StageStyle.UTILITY);
+    }
+
+    default void createModal(Window parent, Scene child, String windowName, boolean resizeable, Modality modality, StageStyle stageStyle) {
         Stage newStage = new Stage();
         newStage.setScene(child);
         newStage.setResizable(resizeable);
         newStage.setTitle(windowName);
-        newStage.initModality(Modality.WINDOW_MODAL);
+        newStage.initModality(modality);
         newStage.initStyle(stageStyle);
-        newStage.setAlwaysOnTop(true);
+//        newStage.setAlwaysOnTop(true);
         newStage.getIcons().add(image);
         newStage.show();
 

--- a/src/main/java/ledger/user_interface/ui_controllers/window/MainPageController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/window/MainPageController.java
@@ -9,6 +9,7 @@ import javafx.scene.Scene;
 import javafx.scene.control.*;
 import javafx.scene.input.KeyCode;
 import javafx.scene.layout.GridPane;
+import javafx.stage.Modality;
 import javafx.stage.StageStyle;
 import javafx.scene.layout.VBox;
 import ledger.controller.DbController;
@@ -18,6 +19,7 @@ import ledger.database.entity.Account;
 import ledger.user_interface.ui_controllers.IUIController;
 import ledger.user_interface.ui_controllers.Startup;
 import ledger.user_interface.ui_controllers.component.AccountInfo;
+import ledger.user_interface.ui_controllers.component.LogoutButton;
 import ledger.user_interface.ui_controllers.component.TransactionTableView;
 
 import java.net.URL;
@@ -46,20 +48,18 @@ public class MainPageController extends GridPane implements Initializable, IUICo
     private Button trackSpendingBtn;
     @FXML
     private Button addTransactionBtn;
-    //    @FXML
-//    private AccountBalanceLabel accountBalanceLabel;
     @FXML
     private VBox accountsVBox;
     @FXML
     private ListView<AccountInfo> accountListView;
-    //    @FXML
-//    private FilteringAccountDropdown chooseAccount;
     @FXML
     private Button searchButton;
     @FXML
     private Button clearButton;
     @FXML
     private TextField searchTextField;
+    @FXML
+    private LogoutButton logoutBtn;
     // Transaction table UI objects
     @FXML
     private TransactionTableView transactionTableView;
@@ -222,7 +222,7 @@ public class MainPageController extends GridPane implements Initializable, IUICo
     private void createExpenditureChartsPage() {
         ExpenditureChartsController chartController = new ExpenditureChartsController();
         Scene scene = new Scene(chartController);
-        this.createModal(this.getScene().getWindow(), scene, "Expenditure Charts", true, StageStyle.DECORATED);
+        this.createModal(this.getScene().getWindow(), scene, "Expenditure Charts", true, Modality.APPLICATION_MODAL, StageStyle.DECORATED);
     }
 
     /**


### PR DESCRIPTION
Addressing GitHub Issues #217 & #220

I changed the behavior of child modal so they block interaction with their parent (the main page) but are no longer forced to be on top. The error dialogues will now appear on top of the modal windows. The user will have to close (or complete & submit) the child modal to resume interaction with the main page window. This also prevents the user from logging out with child windows still open.

Unfortunately, this prohibits the user from using two application windows at once (though, I don't see many use cases for this besides maybe main page + expenditure charts). I can change it so the expenditure charts window does not block interaction with the main page, but then the expenditure charts window also stays open upon logout. What do you guys think?

Pull this down and test it well, please!