### PR TITLE
[LED-163] Updated applicale converters to read in check numbers

### DIFF
--- a/src/main/java/ledger/io/input/AbstractQFXConverter.java
+++ b/src/main/java/ledger/io/input/AbstractQFXConverter.java
@@ -23,13 +23,13 @@ import java.util.regex.Pattern;
 /**
  * Abstract Base Class for handling UFX file conversions into a list of {@link Transaction} Objects
  */
-public abstract class AbstractUFXConverter implements IInAdapter<Transaction> {
+public abstract class AbstractQFXConverter implements IInAdapter<Transaction> {
 
     private final File qfxFile;
     private final Account account;
     private final boolean missingClosingTags;
 
-    public AbstractUFXConverter(File file, Account account, boolean missingClosingTags) {
+    public AbstractQFXConverter(File file, Account account, boolean missingClosingTags) {
         this.qfxFile = file;
         this.account = account;
         this.missingClosingTags = missingClosingTags;

--- a/src/main/java/ledger/io/input/AmericanExpressSavingsQFXConverter.java
+++ b/src/main/java/ledger/io/input/AmericanExpressSavingsQFXConverter.java
@@ -14,7 +14,7 @@ import java.util.List;
 /**
  * Handles the converting of Quicken Qxf files of the old format into our internal transaction objects.
  */
-public class AmericanExpressSavingsQFXConverter extends AbstractUFXConverter {
+public class AmericanExpressSavingsQFXConverter extends AbstractQFXConverter {
 
     public AmericanExpressSavingsQFXConverter(File file, Account account) {
         super(file, account, false);

--- a/src/main/java/ledger/io/input/FifthThirdBankQFXConverter.java
+++ b/src/main/java/ledger/io/input/FifthThirdBankQFXConverter.java
@@ -14,7 +14,7 @@ import java.util.List;
 /**
  * Handles the converting of Quicken Qxf files of the old format into our internal transaction objects.
  */
-public class FifthThirdBankQFXConverter extends AbstractUFXConverter {
+public class FifthThirdBankQFXConverter extends AbstractQFXConverter {
 
     public FifthThirdBankQFXConverter(File file, Account account) {
         super(file, account, true);

--- a/src/main/java/ledger/io/input/FirstDataCorpCSVConverter.java
+++ b/src/main/java/ledger/io/input/FirstDataCorpCSVConverter.java
@@ -38,6 +38,7 @@ public class FirstDataCorpCSVConverter extends AbstractCSVConverter {
                 if (descriptionString.equals("Daily Ledger Bal")) continue;
 
                 String dateString = nextLine[0];
+                String checkNumberString = nextLine[1];
                 String amountString = nextLine[3];
 
                 Date date = AbstractCSVConverter.df.parse(dateString);
@@ -45,6 +46,12 @@ public class FirstDataCorpCSVConverter extends AbstractCSVConverter {
                 int amount = (int) Math.round(Double.parseDouble(amountString) * 100);
 
                 Transaction transaction = new Transaction(date, type, amount, getAccount(), payee, pending, tags, note);
+
+                // Add check number if applicable
+                if (type.getName().equals("Check")) {
+                    int checkNumber = Integer.parseInt(checkNumberString);
+                    transaction.setCheckNumber(checkNumber);
+                }
 
                 transactions.add(transaction);
             }

--- a/src/main/java/ledger/io/input/USBankCSVConverter.java
+++ b/src/main/java/ledger/io/input/USBankCSVConverter.java
@@ -48,6 +48,8 @@ public class USBankCSVConverter extends AbstractCSVConverter {
                 } else if (payeeString.contains("ELECTRONIC DEPOSIT ")) {
                     type = TypeConversion.convert("ACH_CREDIT");
                     payee.setName(payeeString.split("ELECTRONIC DEPOSIT ")[1]);
+                } else if (payeeString.equals("CHECK")) {
+                    type = TypeConversion.convert(payeeString);
                 }
 
                 String[] memoData = memoString.split("Download from usbank\\.com\\.");
@@ -61,6 +63,11 @@ public class USBankCSVConverter extends AbstractCSVConverter {
                 Note note = new Note(memoString);
 
                 Transaction transaction = new Transaction(date, type, amount, getAccount(), payee, false, tags, note);
+
+                // Add check number if applicable
+                if (type.getName().equals("Check")) {
+                    transaction.setCheckNumber(Integer.parseInt(typeString));
+                }
 
                 transactions.add(transaction);
             }

--- a/src/main/java/ledger/io/input/USBankQFXConverter.java
+++ b/src/main/java/ledger/io/input/USBankQFXConverter.java
@@ -14,7 +14,7 @@ import java.util.List;
 /**
  * Handles the converting of Quicken Qxf files of the old format into our internal transaction objects.
  */
-public class USBankQFXConverter extends AbstractUFXConverter {
+public class USBankQFXConverter extends AbstractQFXConverter {
 
     public USBankQFXConverter(File file, Account account) {
         super(file, account, true);
@@ -27,6 +27,10 @@ public class USBankQFXConverter extends AbstractUFXConverter {
         NodeList transactionAmounts = xml.getElementsByTagName("TRNAMT");
         NodeList names = xml.getElementsByTagName("NAME");
         NodeList memos = xml.getElementsByTagName("MEMO");
+        NodeList checkNumbers = xml.getElementsByTagName("CHECKNUM");
+
+        // keep counter for check numbers
+        int checkNumberCounter = 0;
 
         // pull out relevant data and create java objects
         try {
@@ -57,6 +61,13 @@ public class USBankQFXConverter extends AbstractUFXConverter {
                 Note note = new Note(memos.item(i).getTextContent());
 
                 Transaction transaction = new Transaction(date, type, amount, this.getAccount(), payee, false, tags, note);
+
+                // Add check number if applicable
+                if (type.getName().equals("Check")) {
+                    transaction.setCheckNumber(Integer.parseInt(checkNumbers.item(checkNumberCounter).getTextContent()));
+                    checkNumberCounter++;
+                }
+
                 transactions.add(transaction);
             }
         } catch (NullPointerException | DateTimeParseException | NumberFormatException e) {


### PR DESCRIPTION
The following three converters were updated to include check numbers:
- First Data Corp CSV
- US Bank CSV
- US Bank QFX

The following converters were not updated because we do not have appropriate sample files containing check numbers:
- American Express Savings QFX
- Chase Bank CSV
- Fifth Third Bank QFX
- PayPal CSV