### PR TITLE
[LED-180] Implemented stricter debit/credit input sanitization

### DIFF
--- a/src/main/java/ledger/user_interface/ui_controllers/component/tablecolumn/event_handler/AmountEventHandler.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/component/tablecolumn/event_handler/AmountEventHandler.java
@@ -22,6 +22,18 @@ public class AmountEventHandler implements EventHandler<TableColumn.CellEditEven
             return;
         }
 
+        if ((amountToSet < 0) && (transaction.getType().getName().equals("Account Credit") || transaction.getType().getName().equals("Misc Credit"))) {
+            setupErrorPopup("Transactions of the Account Credit/Misc Credit type must have a non-negative amount.", new Exception());
+            ((TransactionTableView) t.getTableView()).updateTransactionTableView();
+            return;
+        }
+
+        if ((amountToSet > 0) && !(transaction.getType().getName().equals("Account Credit") || transaction.getType().getName().equals("Misc Credit"))) {
+            setupErrorPopup("Transactions not of the Account Credit/Misc Credit type cannot have a positive amount.", new Exception());
+            ((TransactionTableView) t.getTableView()).updateTransactionTableView();
+            return;
+        }
+
         transaction.setAmount(amountToSet);
 
         TaskNoReturn task = DbController.INSTANCE.editTransaction(transaction);

--- a/src/main/java/ledger/user_interface/ui_controllers/component/tablecolumn/event_handler/AmountEventHandler.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/component/tablecolumn/event_handler/AmountEventHandler.java
@@ -23,13 +23,13 @@ public class AmountEventHandler implements EventHandler<TableColumn.CellEditEven
         }
 
         if ((amountToSet < 0) && (transaction.getType().getName().equals("Account Credit") || transaction.getType().getName().equals("Misc Credit"))) {
-            setupErrorPopup("Transactions of the Account Credit/Misc Credit type must have a non-negative amount.", new Exception());
+            setupErrorPopup("Transactions of the " + transaction.getType().getName() + " type must have a positive amount.", new Exception());
             ((TransactionTableView) t.getTableView()).updateTransactionTableView();
             return;
         }
 
         if ((amountToSet > 0) && !(transaction.getType().getName().equals("Account Credit") || transaction.getType().getName().equals("Misc Credit"))) {
-            setupErrorPopup("Transactions not of the Account Credit/Misc Credit type cannot have a positive amount.", new Exception());
+            setupErrorPopup("Transactions of the " + transaction.getType().getName() + " type must have a negative amount.", new Exception());
             ((TransactionTableView) t.getTableView()).updateTransactionTableView();
             return;
         }

--- a/src/main/java/ledger/user_interface/ui_controllers/component/tablecolumn/event_handler/TypeEventHandler.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/component/tablecolumn/event_handler/TypeEventHandler.java
@@ -30,20 +30,7 @@ public class TypeEventHandler implements EventHandler<TableColumn.CellEditEvent<
             alert.setContentText("To change the Transaction type from" + transaction.getType().getName() + " to " + typeToSet.getName() + ", the amount will automatically be changed to a positive value, is this okay?");
 
             Optional<ButtonType> result = alert.showAndWait();
-            if (result.get() == ButtonType.OK){
-                transaction.setAmount(-transaction.getAmount());
-                transaction.setType(typeToSet);
-
-                TaskNoReturn task = DbController.INSTANCE.editTransaction(transaction);
-                task.RegisterFailureEvent((e) -> setupErrorPopup("Error editing transaction type.", e));
-
-                task.startTask();
-                task.waitForComplete();
-            } else {
-                // TODO: Figure out how to update the tableview from here
-                transactionTableView.updateTransactionTableView();
-                return;
-            }
+            executeAmountFlipTypeEdit(result, transaction, typeToSet, transactionTableView);
         } else if (transaction.getAmount() > 0 && !(typeToSet.getName().equals("Account Credit") || typeToSet.getName().equals("Misc Credit"))) {
             Alert alert = new Alert(Alert.AlertType.CONFIRMATION);
             alert.setTitle("Edit Transaction Type");
@@ -51,20 +38,7 @@ public class TypeEventHandler implements EventHandler<TableColumn.CellEditEvent<
             alert.setContentText("To change the Transaction type from " + transaction.getType().getName() + " to " + typeToSet.getName() + ", the amount will automatically be changed to a negative value, is this okay?");
 
             Optional<ButtonType> result = alert.showAndWait();
-            if (result.get() == ButtonType.OK){
-                transaction.setAmount(-transaction.getAmount());
-                transaction.setType(typeToSet);
-
-                TaskNoReturn task = DbController.INSTANCE.editTransaction(transaction);
-                task.RegisterFailureEvent((e) -> setupErrorPopup("Error editing transaction type.", e));
-
-                task.startTask();
-                task.waitForComplete();
-            } else {
-                // TODO: and here
-                transactionTableView.updateTransactionTableView();
-                return;
-            }
+            executeAmountFlipTypeEdit(result, transaction, typeToSet, transactionTableView);
         } else {
             transaction.setType(typeToSet);
 
@@ -73,6 +47,22 @@ public class TypeEventHandler implements EventHandler<TableColumn.CellEditEvent<
 
             task.startTask();
             task.waitForComplete();
+        }
+    }
+
+    private void executeAmountFlipTypeEdit(Optional<ButtonType> result, Transaction transaction, Type typeToSet, TransactionTableView transactionTableView) {
+        if (result.get() == ButtonType.OK){
+            transaction.setAmount(-transaction.getAmount());
+            transaction.setType(typeToSet);
+
+            TaskNoReturn task = DbController.INSTANCE.editTransaction(transaction);
+            task.RegisterFailureEvent((e) -> setupErrorPopup("Error editing transaction type.", e));
+
+            task.startTask();
+            task.waitForComplete();
+        } else {
+            transactionTableView.updateTransactionTableView();
+            return;
         }
     }
 }

--- a/src/main/java/ledger/user_interface/ui_controllers/component/tablecolumn/event_handler/TypeEventHandler.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/component/tablecolumn/event_handler/TypeEventHandler.java
@@ -9,6 +9,7 @@ import ledger.controller.register.TaskNoReturn;
 import ledger.database.entity.Transaction;
 import ledger.database.entity.Type;
 import ledger.user_interface.ui_controllers.IUIController;
+import ledger.user_interface.ui_controllers.component.TransactionTableView;
 
 import java.util.Optional;
 
@@ -20,6 +21,7 @@ public class TypeEventHandler implements EventHandler<TableColumn.CellEditEvent<
     public void handle(TableColumn.CellEditEvent<Transaction, Type> t) {
         Transaction transaction = t.getTableView().getItems().get(t.getTablePosition().getRow());
         Type typeToSet = t.getNewValue();
+        TransactionTableView transactionTableView = (TransactionTableView) t.getTableView();
 
         if (transaction.getAmount() < 0 && (typeToSet.getName().equals("Account Credit") || typeToSet.getName().equals("Misc Credit"))) {
             Alert alert = new Alert(Alert.AlertType.CONFIRMATION);
@@ -39,6 +41,7 @@ public class TypeEventHandler implements EventHandler<TableColumn.CellEditEvent<
                 task.waitForComplete();
             } else {
                 // TODO: Figure out how to update the tableview from here
+                transactionTableView.updateTransactionTableView();
                 return;
             }
         } else if (transaction.getAmount() > 0 && !(typeToSet.getName().equals("Account Credit") || typeToSet.getName().equals("Misc Credit"))) {
@@ -59,6 +62,7 @@ public class TypeEventHandler implements EventHandler<TableColumn.CellEditEvent<
                 task.waitForComplete();
             } else {
                 // TODO: and here
+                transactionTableView.updateTransactionTableView();
                 return;
             }
         } else {

--- a/src/main/java/ledger/user_interface/ui_controllers/component/tablecolumn/event_handler/TypeEventHandler.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/component/tablecolumn/event_handler/TypeEventHandler.java
@@ -1,12 +1,16 @@
 package ledger.user_interface.ui_controllers.component.tablecolumn.event_handler;
 
 import javafx.event.EventHandler;
+import javafx.scene.control.Alert;
+import javafx.scene.control.ButtonType;
 import javafx.scene.control.TableColumn;
 import ledger.controller.DbController;
 import ledger.controller.register.TaskNoReturn;
 import ledger.database.entity.Transaction;
 import ledger.database.entity.Type;
 import ledger.user_interface.ui_controllers.IUIController;
+
+import java.util.Optional;
 
 /**
  * {@link EventHandler} for {@link ledger.user_interface.ui_controllers.component.tablecolumn.TypeColumn}
@@ -17,12 +21,52 @@ public class TypeEventHandler implements EventHandler<TableColumn.CellEditEvent<
         Transaction transaction = t.getTableView().getItems().get(t.getTablePosition().getRow());
         Type typeToSet = t.getNewValue();
 
-        transaction.setType(typeToSet);
+        if (transaction.getAmount() < 0 && (typeToSet.getName().equals("Account Credit") || typeToSet.getName().equals("Misc Credit"))) {
+            Alert alert = new Alert(Alert.AlertType.CONFIRMATION);
+            alert.setTitle("Edit Transaction Type");
+            alert.setHeaderText("Transactions of the Account Credit/Misc Credit type must have a non-negative value.");
+            alert.setContentText("To change the Transaction type to Account Credit/Misc Credit, the amount will automatically be changed to a non-negative value, is this okay?");
 
-        TaskNoReturn task = DbController.INSTANCE.editTransaction(transaction);
-        task.RegisterFailureEvent((e) -> setupErrorPopup("Error editing transaction type.", e));
+            Optional<ButtonType> result = alert.showAndWait();
+            if (result.get() == ButtonType.OK){
+                transaction.setAmount(-transaction.getAmount());
+                transaction.setType(typeToSet);
 
-        task.startTask();
-        task.waitForComplete();
+                TaskNoReturn task = DbController.INSTANCE.editTransaction(transaction);
+                task.RegisterFailureEvent((e) -> setupErrorPopup("Error editing transaction type.", e));
+
+                task.startTask();
+                task.waitForComplete();
+            } else {
+                return;
+            }
+        } else if (transaction.getAmount() > 0 && !(typeToSet.getName().equals("Account Credit") || typeToSet.getName().equals("Misc Credit"))) {
+            Alert alert = new Alert(Alert.AlertType.CONFIRMATION);
+            alert.setTitle("Edit Transaction Type");
+            alert.setHeaderText("Transactions not of the Account Credit/Misc Credit type cannot have a positive value.");
+            alert.setContentText("To change the Transaction type from Account Credit/Misc Credit, the amount will automatically be changed to a negative value, is this okay?");
+
+            Optional<ButtonType> result = alert.showAndWait();
+            if (result.get() == ButtonType.OK){
+                transaction.setAmount(-transaction.getAmount());
+                transaction.setType(typeToSet);
+
+                TaskNoReturn task = DbController.INSTANCE.editTransaction(transaction);
+                task.RegisterFailureEvent((e) -> setupErrorPopup("Error editing transaction type.", e));
+
+                task.startTask();
+                task.waitForComplete();
+            } else {
+                return;
+            }
+        } else {
+            transaction.setType(typeToSet);
+
+            TaskNoReturn task = DbController.INSTANCE.editTransaction(transaction);
+            task.RegisterFailureEvent((e) -> setupErrorPopup("Error editing transaction type.", e));
+
+            task.startTask();
+            task.waitForComplete();
+        }
     }
 }

--- a/src/main/java/ledger/user_interface/ui_controllers/component/tablecolumn/event_handler/TypeEventHandler.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/component/tablecolumn/event_handler/TypeEventHandler.java
@@ -27,7 +27,7 @@ public class TypeEventHandler implements EventHandler<TableColumn.CellEditEvent<
             Alert alert = new Alert(Alert.AlertType.CONFIRMATION);
             alert.setTitle("Edit Transaction Type");
             alert.setHeaderText("Transactions of the " + typeToSet.getName() + " type must have a positive amount.");
-            alert.setContentText("To change the Transaction type from" + transaction.getType().getName() + " to " + typeToSet.getName() + ", the amount will automatically be changed to a positive value, is this okay?");
+            alert.setContentText("To change the Transaction type from " + transaction.getType().getName() + " to " + typeToSet.getName() + ", the amount will automatically be changed to a positive value, is this okay?");
 
             Optional<ButtonType> result = alert.showAndWait();
             executeAmountFlipTypeEdit(result, transaction, typeToSet, transactionTableView);

--- a/src/main/java/ledger/user_interface/ui_controllers/component/tablecolumn/event_handler/TypeEventHandler.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/component/tablecolumn/event_handler/TypeEventHandler.java
@@ -24,8 +24,8 @@ public class TypeEventHandler implements EventHandler<TableColumn.CellEditEvent<
         if (transaction.getAmount() < 0 && (typeToSet.getName().equals("Account Credit") || typeToSet.getName().equals("Misc Credit"))) {
             Alert alert = new Alert(Alert.AlertType.CONFIRMATION);
             alert.setTitle("Edit Transaction Type");
-            alert.setHeaderText("Transactions of the Account Credit/Misc Credit type must have a non-negative value.");
-            alert.setContentText("To change the Transaction type to Account Credit/Misc Credit, the amount will automatically be changed to a non-negative value, is this okay?");
+            alert.setHeaderText("Transactions of the " + typeToSet.getName() + " type must have a positive amount.");
+            alert.setContentText("To change the Transaction type from" + transaction.getType().getName() + " to " + typeToSet.getName() + ", the amount will automatically be changed to a positive value, is this okay?");
 
             Optional<ButtonType> result = alert.showAndWait();
             if (result.get() == ButtonType.OK){
@@ -38,13 +38,14 @@ public class TypeEventHandler implements EventHandler<TableColumn.CellEditEvent<
                 task.startTask();
                 task.waitForComplete();
             } else {
+                // TODO: Figure out how to update the tableview from here
                 return;
             }
         } else if (transaction.getAmount() > 0 && !(typeToSet.getName().equals("Account Credit") || typeToSet.getName().equals("Misc Credit"))) {
             Alert alert = new Alert(Alert.AlertType.CONFIRMATION);
             alert.setTitle("Edit Transaction Type");
-            alert.setHeaderText("Transactions not of the Account Credit/Misc Credit type cannot have a positive value.");
-            alert.setContentText("To change the Transaction type from Account Credit/Misc Credit, the amount will automatically be changed to a negative value, is this okay?");
+            alert.setHeaderText("Transactions of the " + typeToSet.getName() + " type must have a negative amount.");
+            alert.setContentText("To change the Transaction type from " + transaction.getType().getName() + " to " + typeToSet.getName() + ", the amount will automatically be changed to a negative value, is this okay?");
 
             Optional<ButtonType> result = alert.showAndWait();
             if (result.get() == ButtonType.OK){
@@ -57,6 +58,7 @@ public class TypeEventHandler implements EventHandler<TableColumn.CellEditEvent<
                 task.startTask();
                 task.waitForComplete();
             } else {
+                // TODO: and here
                 return;
             }
         } else {

--- a/src/main/java/ledger/user_interface/ui_controllers/window/TransactionPopupController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/window/TransactionPopupController.java
@@ -50,12 +50,12 @@ public class TransactionPopupController extends GridPane implements Initializabl
             if (transaction != null) {
 
                 if ((transaction.getAmount() < 0) && (transaction.getType().getName().equals("Account Credit") || transaction.getType().getName().equals("Misc Credit"))) {
-                    setupErrorPopup("Transactions of the Account Credit/Misc Credit type must have a non-negative amount.", new Exception());
+                    setupErrorPopup("Transactions of the " + transaction.getType().getName() + " type must have a positive amount.", new Exception());
                     return;
                 }
 
                 if ((transaction.getAmount() > 0) && !(transaction.getType().getName().equals("Account Credit") || transaction.getType().getName().equals("Misc Credit"))) {
-                    setupErrorPopup("Transactions not of the Account Credit/Misc Credit type cannot have a positive amount.", new Exception());
+                    setupErrorPopup("Transactions of the " + transaction.getType().getName() + " type must have a negative amount.", new Exception());
                     return;
                 }
 

--- a/src/main/java/ledger/user_interface/ui_controllers/window/TransactionPopupController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/window/TransactionPopupController.java
@@ -48,6 +48,17 @@ public class TransactionPopupController extends GridPane implements Initializabl
         this.addTrnxnSubmitButton.setOnAction((event) -> {
             Transaction transaction = transactionInput.getTransactionSubmission();
             if (transaction != null) {
+
+                if ((transaction.getAmount() < 0) && (transaction.getType().getName().equals("Account Credit") || transaction.getType().getName().equals("Misc Credit"))) {
+                    setupErrorPopup("Transactions of the Account Credit/Misc Credit type must have a non-negative amount.", new Exception());
+                    return;
+                }
+
+                if ((transaction.getAmount() > 0) && !(transaction.getType().getName().equals("Account Credit") || transaction.getType().getName().equals("Misc Credit"))) {
+                    setupErrorPopup("Transactions not of the Account Credit/Misc Credit type cannot have a positive amount.", new Exception());
+                    return;
+                }
+
                 TaskNoReturn task = DbController.INSTANCE.insertTransaction(transaction);
                 task.RegisterSuccessEvent(this::closeWindow);
                 task.RegisterFailureEvent(Throwable::printStackTrace);


### PR DESCRIPTION
When entering transactions via the Add Transaction model or editing transaction in the table view, transactions of the Account Credit/Misc Credit types are restricted to non-negative amounts, and all other transaction types are restricted to non-positive amounts.

When editing transactions in the table view, if the user tries to switch a transaction's type to Account Credit/Misc Credit and the transaction has a negative amount, a confirmation dialogue will appear and ask the user if it's okay to flip the amount's sign to positive. If the user confirms, the edit goes through. If not, nothing happens. Vice versa for switching off of Account Credit/Misc Credit for transactions with positive amounts.