### PR TITLE
Last used Db file is no longer suggested if it doesnt exist, First time use update

### DIFF
--- a/src/main/java/ledger/user_interface/ui_controllers/window/LoginPageController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/window/LoginPageController.java
@@ -65,21 +65,16 @@ public class LoginPageController extends GridPane implements Initializable, IUIC
 
         try {
             String lastDBFile = PreferenceHandler.getStringPreference(PreferenceHandler.LAST_DATABASE_FILE_KEY);
-            if (lastDBFile != null)
-                setChosenFile(new File(lastDBFile));
+            if (lastDBFile != null) {
+                File file = new File(lastDBFile);
+                if(file.exists()&&!file.isDirectory()){
+                    this.setChosenFile(file);
+                }
+            } else{
+                setUpIntroHelp();
+            }
         } catch (Exception e) {
             this.setupErrorPopup("Previous file not Found: Does not exist or has been moved", e);
-        }
-        File initDir = new File(System.getProperty("user.home"));
-        File[] listFiles = initDir.listFiles();
-        boolean containsDbFile = false;
-        for (File f : listFiles) {
-            if (f.isFile() && f.getName().endsWith(".mv.db")) {
-                containsDbFile = true;
-            }
-        }
-        if (!containsDbFile) {
-            setUpIntroHelp();
         }
     }
 

--- a/src/main/java/ledger/user_interface/ui_controllers/window/LoginPageController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/window/LoginPageController.java
@@ -62,20 +62,17 @@ public class LoginPageController extends GridPane implements Initializable, IUIC
                 login();
             }
         });
-
-        try {
-            String lastDBFile = PreferenceHandler.getStringPreference(PreferenceHandler.LAST_DATABASE_FILE_KEY);
-            if (lastDBFile != null) {
-                File file = new File(lastDBFile);
-                if(file.exists()&&!file.isDirectory()){
-                    this.setChosenFile(file);
-                }
-            } else{
-                setUpIntroHelp();
+        
+        String lastDBFile = PreferenceHandler.getStringPreference(PreferenceHandler.LAST_DATABASE_FILE_KEY);
+        if (lastDBFile != null) {
+            File file = new File(lastDBFile);
+            if (file.exists() && !file.isDirectory()) {
+                this.setChosenFile(file);
             }
-        } catch (Exception e) {
-            this.setupErrorPopup("Previous file not Found: Does not exist or has been moved", e);
+        } else {
+            setUpIntroHelp();
         }
+
     }
 
     /**


### PR DESCRIPTION
This PR addresses to things

1. The Login screen will no longer suggest files that don't exist

2. The first time user popup only occurs if any preference data does not exist.