### PR TITLE
Moved the Ignored Transaction Button to Main page

### DIFF
--- a/src/main/java/ledger/user_interface/ui_controllers/window/IgnoredExpressionPopupController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/window/IgnoredExpressionPopupController.java
@@ -7,6 +7,7 @@ import javafx.scene.control.Button;
 import javafx.scene.control.ComboBox;
 import javafx.scene.control.TextField;
 import javafx.scene.layout.GridPane;
+import javafx.stage.WindowEvent;
 import ledger.controller.DbController;
 import ledger.controller.register.TaskNoReturn;
 import ledger.database.entity.IgnoredExpression;
@@ -29,6 +30,8 @@ public class IgnoredExpressionPopupController extends GridPane implements Initia
     private ComboBox<Boolean> newExpRule;
     @FXML
     private Button addExpButton;
+    @FXML
+    private Button doneButton;
 
     public IgnoredExpressionPopupController() {
 
@@ -41,6 +44,9 @@ public class IgnoredExpressionPopupController extends GridPane implements Initia
         this.newExpRule.setItems(FXCollections.observableArrayList(true, false));
         this.newExpRule.setConverter(new IsMatchConverter());
         this.addExpButton.setOnAction(event -> addExpression());
+        this.doneButton.setOnAction((actionEvent) ->
+                this.getScene().getWindow().fireEvent(
+                        new WindowEvent(this.getScene().getWindow(), WindowEvent.WINDOW_CLOSE_REQUEST)));
 
     }
 

--- a/src/main/java/ledger/user_interface/ui_controllers/window/ImportTransactionsPopupController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/window/ImportTransactionsPopupController.java
@@ -46,9 +46,6 @@ public class ImportTransactionsPopupController extends GridPane implements Initi
     @FXML
     private ConverterDropdown converterSelector;
 
-    @FXML
-    private Button ignoreEditorButton;
-
     private final static String pageLoc = "/fxml_files/ImportTransactionsPopup.fxml";
 
     ImportTransactionsPopupController() {
@@ -68,11 +65,6 @@ public class ImportTransactionsPopupController extends GridPane implements Initi
      */
     @Override
     public void initialize(URL fxmlFileLocation, ResourceBundle resources) {
-        this.ignoreEditorButton.setOnAction(event -> {
-            IgnoredExpressionPopupController ignoredExpressionPopupController = new IgnoredExpressionPopupController();
-            Scene scene = new Scene(ignoredExpressionPopupController);
-            this.createModal(this.getScene().getWindow(), scene, "Ignored Transactions");
-        });
         fileSelector.addFileExtensionFilter(new ExtensionFilter("All files (*.*)", "*.*"));
         fileSelector.addFileExtensionFilter(new ExtensionFilter("CSV files (*.csv)", "*.csv"));
         fileSelector.addFileExtensionFilter(new ExtensionFilter("QFX files (*.qfx)", "*.qfx"));

--- a/src/main/java/ledger/user_interface/ui_controllers/window/MainPageController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/window/MainPageController.java
@@ -61,6 +61,8 @@ public class MainPageController extends GridPane implements Initializable, IUICo
     // Transaction table UI objects
     @FXML
     private TransactionTableView transactionTableView;
+    @FXML
+    private Button addIgnoreTransactionButton;
 
     public MainPageController() {
         INSTANCE = this;
@@ -129,6 +131,7 @@ public class MainPageController extends GridPane implements Initializable, IUICo
         });
 
         this.payeeEditorButton.setOnAction(this::openAutoTaggingEditor);
+        this.addIgnoreTransactionButton.setOnAction(this::openIgnoredTransactionEditor);
 
         this.setOnKeyPressed(event -> {
             if (!event.isControlDown())
@@ -139,6 +142,12 @@ public class MainPageController extends GridPane implements Initializable, IUICo
 
             this.undo();
         });
+    }
+
+    private void openIgnoredTransactionEditor(ActionEvent actionEvent) {
+        IgnoredExpressionPopupController ignoredExpressionPopupController = new IgnoredExpressionPopupController();
+        Scene scene = new Scene(ignoredExpressionPopupController);
+        this.createModal(this.getScene().getWindow(), scene, "Automatic Ignored Transactions");
     }
 
     /**

--- a/src/main/java/ledger/user_interface/ui_controllers/window/MainPageController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/window/MainPageController.java
@@ -147,7 +147,7 @@ public class MainPageController extends GridPane implements Initializable, IUICo
     private void openIgnoredTransactionEditor(ActionEvent actionEvent) {
         IgnoredExpressionPopupController ignoredExpressionPopupController = new IgnoredExpressionPopupController();
         Scene scene = new Scene(ignoredExpressionPopupController);
-        this.createModal(this.getScene().getWindow(), scene, "Automatic Ignored Transactions");
+        this.createModal(this.getScene().getWindow(), scene, "Automatically Ignored Transactions");
     }
 
     /**

--- a/src/main/resources/fxml_files/IgnoredTransactionPopup.fxml
+++ b/src/main/resources/fxml_files/IgnoredTransactionPopup.fxml
@@ -14,29 +14,30 @@
 <?import javafx.scene.text.Text?>
 <?import ledger.user_interface.ui_controllers.component.IgnoredExpressionTableView?>
 
-<fx:root fx:id="ignoredTransGridPane" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" prefHeight="240.0" prefWidth="600.0" style="-fx-background-color: #ffffff;" type="GridPane" xmlns="http://javafx.com/javafx/8.0.102-ea" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root fx:id="ignoredTransGridPane" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" style="-fx-background-color: #ffffff;" type="GridPane" xmlns="http://javafx.com/javafx/8.0.111" xmlns:fx="http://javafx.com/fxml/1">
     <columnConstraints>
         <ColumnConstraints hgrow="ALWAYS" maxWidth="-Infinity" minWidth="-Infinity" prefWidth="130.0" />
         <ColumnConstraints hgrow="SOMETIMES" maxWidth="1.7976931348623157E308" minWidth="-Infinity" prefWidth="170.0" />
       <ColumnConstraints hgrow="SOMETIMES" maxWidth="1.7976931348623157E308" minWidth="10.0" prefWidth="300.0" />
     </columnConstraints>
     <rowConstraints>
-        <RowConstraints maxHeight="40.0" minHeight="3.0" prefHeight="40.0" vgrow="SOMETIMES" />
-        <RowConstraints maxHeight="60.0" minHeight="10.0" prefHeight="60.0" vgrow="SOMETIMES" />
-        <RowConstraints maxHeight="60.0" minHeight="10.0" prefHeight="60.0" vgrow="SOMETIMES" />
-        <RowConstraints maxHeight="60.0" minHeight="10.0" prefHeight="80.0" vgrow="SOMETIMES" />
+        <RowConstraints maxHeight="-Infinity" minHeight="-Infinity" prefHeight="50.0" vgrow="SOMETIMES" />
+        <RowConstraints maxHeight="-Infinity" minHeight="10.0" vgrow="SOMETIMES" />
+        <RowConstraints maxHeight="-Infinity" minHeight="10.0" vgrow="SOMETIMES" />
+        <RowConstraints maxHeight="-Infinity" minHeight="10.0" vgrow="SOMETIMES" />
+      <RowConstraints maxHeight="1.7976931348623157E308" minHeight="30.0" vgrow="SOMETIMES" />
     </rowConstraints>
     <children>
         <Pane fx:id="header" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" GridPane.columnSpan="3" GridPane.hgrow="ALWAYS" GridPane.vgrow="ALWAYS">
             <children>
-                <Text fx:id="title" layoutX="14.0" layoutY="26.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Ignored Transactions" wrappingWidth="307.203125">
+                <Text fx:id="title" layoutX="14.0" layoutY="32.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Ignored Transactions" wrappingWidth="307.203125">
                     <font>
                         <Font name="Calibri" size="28.0" />
                     </font>
                 </Text>
             </children>
          <GridPane.margin>
-            <Insets top="1.0" />
+            <Insets />
          </GridPane.margin>
         </Pane>
         <Text fx:id="accountNameLabel" strokeType="OUTSIDE" strokeWidth="0.0" text="Expression" textAlignment="RIGHT" GridPane.halignment="RIGHT" GridPane.rowIndex="1">
@@ -56,7 +57,7 @@
         </Text>
         <Button fx:id="addExpButton" mnemonicParsing="false" prefHeight="30.0" prefWidth="200.0" text="Add" GridPane.columnIndex="1" GridPane.halignment="CENTER" GridPane.rowIndex="3">
             <GridPane.margin>
-                <Insets left="15.0" right="15.0" />
+                <Insets bottom="5.0" left="15.0" right="15.0" top="5.0" />
             </GridPane.margin>
             <font>
                 <Font name="Calibri Light" size="16.0" />
@@ -70,10 +71,15 @@
             <Insets left="15.0" right="15.0" />
          </GridPane.margin>
       </ComboBox>
-      <IgnoredExpressionTableView editable="true" prefHeight="200.0" prefWidth="300.0" GridPane.columnIndex="2" GridPane.halignment="LEFT" GridPane.rowIndex="1" GridPane.rowSpan="3" GridPane.valignment="BASELINE">
+      <IgnoredExpressionTableView editable="true" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" GridPane.columnIndex="2" GridPane.halignment="LEFT" GridPane.rowIndex="1" GridPane.rowSpan="4" GridPane.valignment="BASELINE">
          <GridPane.margin>
             <Insets />
          </GridPane.margin></IgnoredExpressionTableView>
+      <Button fx:id="doneButton" maxWidth="1.7976931348623157E308" mnemonicParsing="false" text="Done" GridPane.columnIndex="1" GridPane.halignment="CENTER" GridPane.rowIndex="4" GridPane.valignment="TOP">
+         <GridPane.margin>
+            <Insets bottom="10.0" left="15.0" right="15.0" top="10.0" />
+         </GridPane.margin>
+      </Button>
     </children>
     <stylesheets>
         <URL value="@../css/colorStyle.css" />

--- a/src/main/resources/fxml_files/IgnoredTransactionPopup.fxml
+++ b/src/main/resources/fxml_files/IgnoredTransactionPopup.fxml
@@ -30,7 +30,7 @@
     <children>
         <Pane fx:id="header" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" GridPane.columnSpan="3" GridPane.hgrow="ALWAYS" GridPane.vgrow="ALWAYS">
             <children>
-                <Text fx:id="title" layoutX="14.0" layoutY="32.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Ignored Transactions" wrappingWidth="307.203125">
+                <Text fx:id="title" layoutX="14.0" layoutY="32.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Automatic Ignored Transactions">
                     <font>
                         <Font name="Calibri" size="28.0" />
                     </font>

--- a/src/main/resources/fxml_files/IgnoredTransactionPopup.fxml
+++ b/src/main/resources/fxml_files/IgnoredTransactionPopup.fxml
@@ -30,7 +30,7 @@
     <children>
         <Pane fx:id="header" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" GridPane.columnSpan="3" GridPane.hgrow="ALWAYS" GridPane.vgrow="ALWAYS">
             <children>
-                <Text fx:id="title" layoutX="14.0" layoutY="32.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Automatic Ignored Transactions">
+                <Text fx:id="title" layoutX="14.0" layoutY="32.0" strokeType="OUTSIDE" strokeWidth="0.0" text="Automatically Ignored Transactions">
                     <font>
                         <Font name="Calibri" size="28.0" />
                     </font>

--- a/src/main/resources/fxml_files/ImportTransactionsPopup.fxml
+++ b/src/main/resources/fxml_files/ImportTransactionsPopup.fxml
@@ -14,7 +14,7 @@
 <?import ledger.user_interface.ui_controllers.component.ConverterDropdown?>
 <?import ledger.user_interface.ui_controllers.component.FileSelectorButton?>
 
-<fx:root fx:id="addAcctGridPane" alignment="CENTER" scaleShape="false" style="-fx-background-color: #ffffff;" type="GridPane" xmlns="http://javafx.com/javafx/8.0.102-ea" xmlns:fx="http://javafx.com/fxml/1">
+<fx:root fx:id="addAcctGridPane" alignment="CENTER" scaleShape="false" style="-fx-background-color: #ffffff;" type="GridPane" xmlns="http://javafx.com/javafx/8.0.111" xmlns:fx="http://javafx.com/fxml/1">
     <columnConstraints>
         <ColumnConstraints hgrow="ALWAYS" maxWidth="1.7976931348623157E308" minWidth="-Infinity" prefWidth="200.0" />
         <ColumnConstraints hgrow="ALWAYS" maxWidth="1.7976931348623157E308" minWidth="-Infinity" prefWidth="200.0" />
@@ -69,10 +69,6 @@
                 <Cursor fx:constant="HAND" />
             </cursor>
         </Button>
-      <Button fx:id="ignoreEditorButton" mnemonicParsing="false" text="Ignored Editor" GridPane.halignment="CENTER" GridPane.rowIndex="3" GridPane.valignment="CENTER">
-         <padding>
-            <Insets bottom="5.0" left="10.0" right="10.0" top="5.0" />
-         </padding></Button>
     </children>
     <stylesheets>
         <URL value="@../css/colorStyle.css" />

--- a/src/main/resources/fxml_files/MainPage.fxml
+++ b/src/main/resources/fxml_files/MainPage.fxml
@@ -95,6 +95,7 @@
                 </Button>
                                               <Button fx:id="importTransactionsBtn" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" mnemonicParsing="false" text="Import Transactions" textAlignment="CENTER" />
                                               <Button fx:id="payeeEditorButton" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" minHeight="-Infinity" minWidth="-Infinity" mnemonicParsing="false" text="Add Automatic Tags" />
+                                          <Button fx:id="addIgnoreTransactionButton" maxHeight="1.7976931348623157E308" maxWidth="1.7976931348623157E308" mnemonicParsing="false" text="Ignored Transactions" />
                                        </children>
                                     </VBox>
                                  </children>


### PR DESCRIPTION
Also renamed the window / button. 

On main page it is called `Ignored Transactions` and its title is `Automatic Ignored Transactions`

I could not get the title to fit on the button without making it two rows so just cut off the automatic part from the button.


#254 Should be merged first as this is a branch of that.