### PR TITLE
[LED-120] Added auto detection of file types during import

### DIFF
--- a/src/main/java/ledger/user_interface/ui_controllers/window/ImportTransactionsPopupController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/window/ImportTransactionsPopupController.java
@@ -47,6 +47,9 @@ public class ImportTransactionsPopupController extends GridPane implements Initi
     private ConverterDropdown converterSelector;
 
     private final static String pageLoc = "/fxml_files/ImportTransactionsPopup.fxml";
+    private final static ExtensionFilter allFilesFilter = new ExtensionFilter("All files (*.*)", "*.*");
+    private final static ExtensionFilter csvFilesFilter = new ExtensionFilter("CSV files (*.csv, *.CSV)", "*.csv", "*.CSV");
+    private final static ExtensionFilter qfxFilesFilter = new ExtensionFilter("QFX files (*.qfx, *.QFX)", "*.qfx", "*.QFX");
 
     ImportTransactionsPopupController() {
         this.initController(pageLoc, this, "Error on transaction popup startup: ");
@@ -65,11 +68,23 @@ public class ImportTransactionsPopupController extends GridPane implements Initi
      */
     @Override
     public void initialize(URL fxmlFileLocation, ResourceBundle resources) {
-        fileSelector.addFileExtensionFilter(new ExtensionFilter("All files (*.*)", "*.*"));
-        fileSelector.addFileExtensionFilter(new ExtensionFilter("CSV files (*.csv)", "*.csv"));
-        fileSelector.addFileExtensionFilter(new ExtensionFilter("QFX files (*.qfx)", "*.qfx"));
+        fileSelector.addFileExtensionFilter(allFilesFilter);
+        fileSelector.addFileExtensionFilter(csvFilesFilter);
+        fileSelector.addFileExtensionFilter(qfxFilesFilter);
         importButton.setOnAction(this::importFile);
         // TODO Hook up insert
+        converterSelector.setOnAction(this::applyExtensionFilters);
+    }
+
+    private void applyExtensionFilters(ActionEvent actionEvent) {
+        fileSelector.clearFileExtensionFilter();
+        ImportController.Converter converter = converterSelector.getFileConverter();
+        if (converter.toString().contains("CSV")) {
+            fileSelector.addFileExtensionFilter(csvFilesFilter);
+        } else if (converter.toString().contains("QFX")) {
+            fileSelector.addFileExtensionFilter(qfxFilesFilter);
+        }
+        fileSelector.addFileExtensionFilter(allFilesFilter);
     }
 
     private void importFile(ActionEvent actionEvent) {


### PR DESCRIPTION
Selecting a file type will modify the file chooser's extension filters appropriately. I left in an All Files filter, but made the more specific one the default.

I discovered a couple TODOs in` ImportTransactionsPopController.java`. Made an issue for them since they seem to have fallen off our radar