### PR TITLE
Fix allow all amounts for check and cash transactions

### DIFF
--- a/src/main/java/ledger/user_interface/ui_controllers/component/tablecolumn/event_handler/AmountEventHandler.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/component/tablecolumn/event_handler/AmountEventHandler.java
@@ -34,7 +34,7 @@ public class AmountEventHandler implements EventHandler<TableColumn.CellEditEven
             return;
         }
 
-        if ((amountToSet > 0) && !(transaction.getType().getName().equals("Account Credit") || transaction.getType().getName().equals("Misc Credit")) && !(transaction.getType().getName().equals("Transfer"))) {
+        if ((amountToSet > 0) && !(transaction.getType().getName().equals("Account Credit") || transaction.getType().getName().equals("Misc Credit") || transaction.getType().getName().equals("Cash") || transaction.getType().getName().equals("Check")) && !(transaction.getType().getName().equals("Transfer"))) {
             setupErrorPopup("Transactions of the " + transaction.getType().getName() + " type must have a negative amount.", new Exception());
             t.getTableView().refresh();
             return;

--- a/src/main/java/ledger/user_interface/ui_controllers/component/tablecolumn/event_handler/TypeEventHandler.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/component/tablecolumn/event_handler/TypeEventHandler.java
@@ -35,7 +35,7 @@ public class TypeEventHandler implements EventHandler<TableColumn.CellEditEvent<
 
             Optional<ButtonType> result = alert.showAndWait();
             executeAmountFlipTypeEdit(result, transaction, typeToSet, transactionTableView);
-        } else if (transaction.getAmount() > 0 && !(typeToSet.getName().equals("Account Credit") || typeToSet.getName().equals("Misc Credit"))) {
+        } else if (transaction.getAmount() > 0 && !(typeToSet.getName().equals("Account Credit") || typeToSet.getName().equals("Misc Credit") || transaction.getType().getName().equals("Cash") || transaction.getType().getName().equals("Check"))) {
             Alert alert = new Alert(Alert.AlertType.CONFIRMATION);
             alert.setTitle("Edit Transaction Type");
             alert.setHeaderText("Transactions of the " + typeToSet.getName() + " type must have a negative amount.");

--- a/src/main/java/ledger/user_interface/ui_controllers/window/RecurringTransactionController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/window/RecurringTransactionController.java
@@ -144,7 +144,7 @@ public class RecurringTransactionController extends GridPane implements IUIContr
             return;
         }
 
-        if ((amount > 0) && !(type.getName().equals("Account Credit") || type.getName().equals("Misc Credit"))) {
+        if ((amount > 0) && !(type.getName().equals("Account Credit") || type.getName().equals("Misc Credit") || type.getName().equals("Cash") || type.getName().equals("Check"))) {
             setupErrorPopup("Transactions of the " + type.getName() + " type must have a negative amount.");
             return;
         }

--- a/src/main/java/ledger/user_interface/ui_controllers/window/TransactionPopupController.java
+++ b/src/main/java/ledger/user_interface/ui_controllers/window/TransactionPopupController.java
@@ -54,7 +54,7 @@ public class TransactionPopupController extends GridPane implements Initializabl
                     return;
                 }
 
-                if ((transaction.getAmount() > 0) && !(transaction.getType().getName().equals("Account Credit") || transaction.getType().getName().equals("Misc Credit") || transaction.getType().getName().equals("Transfer"))) {
+                if ((transaction.getAmount() > 0) && !(transaction.getType().getName().equals("Account Credit") || transaction.getType().getName().equals("Misc Credit") || transaction.getType().getName().equals("Transfer") || transaction.getType().getName().equals("Cash") || transaction.getType().getName().equals("Check"))) {
                     setupErrorPopup("Transactions of the " + transaction.getType().getName() + " type must have a negative amount.", new Exception());
                     return;
                 }


### PR DESCRIPTION
I changed the Add Transaction modal to allow transactions of Check and Cash types to have any dollar amount, both negative and positive. I also modified the logic in the Type and Amount column event handlers to behave this way as well. I believe I covered all cases, but please test this!